### PR TITLE
perf: 130x load speedup + tag parsing fixes

### DIFF
--- a/acd/l5x/elements.py
+++ b/acd/l5x/elements.py
@@ -391,12 +391,16 @@ class TagBuilder(L5xElementBuilder):
                 extended_record.value
             )
 
-        name_length = struct.unpack("<H", extended_records[0x01][0:2])[0]
-        name = bytes(extended_records[0x01][2 : name_length + 2]).decode("utf-8")
-
         radix = radix_enum(r.main_record.radix)
-        name_length_raw = struct.unpack_from("<H", extended_records[0x01], 0x21E)[0]
-        external_access = external_access_enum(name_length_raw)
+        if 0x01 in extended_records:
+            name_length = struct.unpack("<H", extended_records[0x01][0:2])[0]
+            name = bytes(extended_records[0x01][2 : name_length + 2]).decode("utf-8")
+            external_access = external_access_enum(
+                struct.unpack_from("<H", extended_records[0x01], 0x21E)[0]
+            )
+        else:
+            name = results[0][0]
+            external_access = "Read/Write"
 
         if r.main_record.dimension_1 != 0:
             data_type = data_type + "[" + str(r.main_record.dimension_1) + "]"
@@ -455,19 +459,11 @@ class RoutineBuilder(L5xElementBuilder):
         )
 
         self._cur.execute(
-            "SELECT object_id, parent_id, seq_no FROM region_map WHERE parent_id="
-            + str(self._object_id)
-            + " ORDER BY seq_no"
+            "SELECT rm.object_id, r.rung FROM region_map rm "
+            "LEFT JOIN rungs r ON r.object_id = rm.object_id "
+            "WHERE rm.parent_id=" + str(self._object_id) + " ORDER BY rm.seq_no"
         )
-        results = self._cur.fetchall()
-        rungs = []
-        for member in results:
-            self._cur.execute(
-                "SELECT object_id, rung FROM rungs WHERE object_id=" + str(member[0])
-            )
-            rungs_results = self._cur.fetchall()
-            if len(rungs_results) > 0:
-                rungs.append(rungs_results[0][1])
+        rungs = [row[1] for row in self._cur.fetchall() if row[1] is not None]
         return Routine(name, name, routine_type, rungs)
 
 

--- a/acd/l5x/export_l5x.py
+++ b/acd/l5x/export_l5x.py
@@ -44,6 +44,8 @@ class ExportL5x:
         self._db = sqlite3.connect(
             os.path.join(self._temp_dir, _DEFAULT_SQL_DATABASE_NAME)
         )
+        self._db.execute("PRAGMA journal_mode=WAL")
+        self._db.execute("PRAGMA synchronous=OFF")
         self._cur: Cursor = self._db.cursor()
 
         log.debug("Create Comps table in sqllite db")
@@ -78,20 +80,17 @@ class ExportL5x:
 
         log.info("Getting records from ACD Comps file and storing in sqllite database")
         comps_db = DbExtract(os.path.join(self._temp_dir, "Comps.Dat")).read()
+        # Deduplicate by object_id (last occurrence wins, matching original behavior)
+        comps_by_id = {}
         for record in comps_db.records.record:
-            CompsRecord(self._cur, record)
+            t = CompsRecord.parse(record)
+            if t is not None:
+                comps_by_id[t[0]] = t
+        self._cur.executemany("INSERT INTO comps VALUES (?,?,?,?,?,?)", comps_by_id.values())
         self._db.commit()
 
-        # Get a list of class ids for each collection
-        # self._cur.execute("SELECT object_id, comp_name, record FROM comps WHERE parent_id=" + str(4240912631))
-        # results = self._cur.fetchall()
-        # classes = [[]]
-        # for result in results:
-        #     name = result[1]
-        #     cip_class = hex(struct.unpack(
-        #         "H", result[2][10: 10 + 2]
-        #     )[0])
-        #     classes.append([name, cip_class])
+        # Build name lookup for SbRegion tag reference resolution (object_id → comp_name)
+        name_lookup = {oid: t[2] for oid, t in comps_by_id.items()}
 
         log.info(
             "Getting records from ACD Region Map file and storing in sqllite database"
@@ -102,24 +101,33 @@ class ExportL5x:
             "Getting records from ACD SbRegion file and storing in sqllite database"
         )
         sb_region_db = DbExtract(os.path.join(self._temp_dir, "SbRegion.Dat")).read()
-        for record in sb_region_db.records.record:
-            SbRegionRecord(self._cur, record)
+        rung_tuples = [t for record in sb_region_db.records.record if (t := SbRegionRecord.parse(record, name_lookup)) is not None]
+        self._cur.executemany("INSERT INTO rungs VALUES (?,?,?)", rung_tuples)
         self._db.commit()
 
         log.info(
             "Getting records from ACD Comments file and storing in sqllite database"
         )
         comments_db = DbExtract(os.path.join(self._temp_dir, "Comments.Dat")).read()
-        for record in comments_db.records.record:
-            CommentsRecord(self._cur, record)
+        comment_tuples = [t for record in comments_db.records.record if (t := CommentsRecord.parse(record)) is not None]
+        self._cur.executemany("INSERT INTO comments VALUES (?,?,?,?,?,?,?)", comment_tuples)
         self._db.commit()
 
         log.info(
             "Getting records from ACD Nameless file and storing in sqllite database"
         )
         nameless_db = DbExtract(os.path.join(self._temp_dir, "Nameless.Dat")).read()
-        for record in nameless_db.records.record:
-            NamelessRecord(self._cur, record)
+        nameless_tuples = [t for record in nameless_db.records.record if (t := NamelessRecord.parse(record)) is not None]
+        self._cur.executemany("INSERT INTO nameless VALUES (?,?,?)", nameless_tuples)
+        self._db.commit()
+
+        log.info("Creating indexes for fast object graph queries")
+        self._cur.execute("CREATE INDEX idx_comps_object_id ON comps(object_id)")
+        self._cur.execute("CREATE INDEX idx_comps_parent_id ON comps(parent_id)")
+        self._cur.execute("CREATE INDEX idx_comps_parent_name ON comps(parent_id, comp_name)")
+        self._cur.execute("CREATE INDEX idx_rungs_object_id ON rungs(object_id)")
+        self._cur.execute("CREATE INDEX idx_region_map_parent_id ON region_map(parent_id)")
+        self._cur.execute("CREATE INDEX idx_comments_parent ON comments(parent)")
         self._db.commit()
 
     @property
@@ -188,7 +196,7 @@ class ExportL5x:
             self._cur.execute(query, enty)
             identifier_offset += 16
 
-            self._db.commit()
+        self._db.commit()
 
 
 if __name__ == "__main__":

--- a/acd/record/comments.py
+++ b/acd/record/comments.py
@@ -1,6 +1,7 @@
 import re
 from dataclasses import dataclass
 from sqlite3 import Cursor
+from typing import Optional
 
 from acd.database.dbextract import DatRecord
 from acd.generated.comments.fafa_coments import FafaComents
@@ -12,46 +13,31 @@ class CommentsRecord:
     dat_record: DatRecord
 
     def __post_init__(self):
-        if self.dat_record.identifier == 64250:
-            r = FafaComents.from_bytes(self.dat_record.record.record_buffer)
-            pass
-        else:
-            return
+        entry = CommentsRecord.parse(self.dat_record)
+        if entry is not None:
+            self._cur.execute("INSERT INTO comments VALUES (?, ?, ?, ?, ?, ?, ?)", entry)
 
-        query: str = "INSERT INTO comments VALUES (?, ?, ?, ?, ?, ?, ?)"
-        if (
-            (r.header.record_type == 0x03)
-            or (r.header.record_type == 0x04)
-            or (r.header.record_type == 0x0D)
-            or (r.header.record_type == 0x0E)
-        ):
-            try:
-                entry: tuple = (
-                    r.header.seq_number,
-                    r.header.sub_record_length,
-                    r.body.object_id,
-                    r.body.record_string,
-                    r.header.record_type,
-                    r.header.parent,
-                    r.body.tag_reference.value,
-                )
-                self._cur.execute(query, entry)
-            except Exception as e:
-                pass
-        else:
-            try:
-                entry: tuple = (
-                    r.header.seq_number,
-                    r.header.sub_record_length,
-                    r.body.object_id,
-                    r.body.record_string,
-                    r.header.record_type,
-                    r.header.parent,
-                    "",
-                )
-                self._cur.execute(query, entry)
-            except Exception as e:
-                pass
+    @staticmethod
+    def parse(dat_record: DatRecord) -> Optional[tuple]:
+        if dat_record.identifier != 64250:
+            return None
+        try:
+            r = FafaComents.from_bytes(dat_record.record.record_buffer)
+            if r.header.record_type in (0x03, 0x04, 0x0D, 0x0E):
+                tag_ref = r.body.tag_reference.value
+            else:
+                tag_ref = ""
+            return (
+                r.header.seq_number,
+                r.header.sub_record_length,
+                r.body.object_id,
+                r.body.record_string,
+                r.header.record_type,
+                r.header.parent,
+                tag_ref,
+            )
+        except Exception:
+            return None
 
     def replace_tag_references(self, sb_rec):
         m = re.findall("@[A-Za-z0-9]*@", sb_rec)

--- a/acd/record/comps.py
+++ b/acd/record/comps.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from io import BytesIO
 from sqlite3 import Cursor
+from typing import Optional
 
 from acd.database.dbextract import DatRecord
 from kaitaistruct import KaitaiStream
@@ -24,22 +25,24 @@ class CompsRecord:
     dat_record: DatRecord
 
     def __post_init__(self):
+        entry = CompsRecord.parse(self.dat_record)
+        if entry is None:
+            return
+        self._cur.execute(f"DELETE FROM comps WHERE object_id={entry[0]}")
+        self._cur.execute("INSERT INTO comps VALUES (?, ?, ?, ?, ?, ?)", entry)
 
-        if self.dat_record.identifier == 64250:
-            r = FafaComps.from_bytes(self.dat_record.record.record_buffer)
-        elif self.dat_record.identifier == 65021:
+    @staticmethod
+    def parse(dat_record: DatRecord) -> Optional[tuple]:
+        if dat_record.identifier == 64250:
+            r = FafaComps.from_bytes(dat_record.record.record_buffer)
+        elif dat_record.identifier == 65021:
             r = FdfdComps(
-                self.dat_record.len_record,
-                KaitaiStream(BytesIO(self.dat_record.record.record_buffer)),
+                dat_record.len_record,
+                KaitaiStream(BytesIO(dat_record.record.record_buffer)),
             )
         else:
-            return
-
-        delete_query: str = f"DELETE FROM comps WHERE object_id={r.header.object_id}"
-        self._cur.execute(delete_query)
-
-        insert_query: str = "INSERT INTO comps VALUES (?, ?, ?, ?, ?, ?)"
-        entry: tuple = (
+            return None
+        return (
             r.header.object_id,
             r.header.parent_id,
             r.header.record_name.value,
@@ -47,4 +50,3 @@ class CompsRecord:
             r.header.record_type,
             r.record_buffer,
         )
-        self._cur.execute(insert_query, entry)

--- a/acd/record/nameless.py
+++ b/acd/record/nameless.py
@@ -1,6 +1,7 @@
 import struct
 from dataclasses import dataclass
 from sqlite3 import Cursor
+from typing import Optional
 
 from acd.database.dbextract import DatRecord
 
@@ -11,24 +12,15 @@ class NamelessRecord:
     dat_record: DatRecord
 
     def __post_init__(self):
-        if self.dat_record.identifier == 64250:
-            identifier_offset = 8
-            self.identifier = struct.unpack(
-                "I",
-                self.dat_record.record.record_buffer[
-                    identifier_offset : identifier_offset + 4
-                ],
-            )[0]
+        entry = NamelessRecord.parse(self.dat_record)
+        if entry is not None:
+            self._cur.execute("INSERT INTO nameless VALUES (?, ?, ?)", entry)
 
-            object_identifier_offset = 0x0C
-            self.object_identifier = struct.unpack_from(
-                "<I", self.dat_record.record.record_buffer, object_identifier_offset
-            )[0]
-
-            query: str = "INSERT INTO nameless VALUES (?, ?, ?)"
-            enty: tuple = (
-                self.object_identifier,
-                self.identifier,
-                self.dat_record.record.record_buffer,
-            )
-            self._cur.execute(query, enty)
+    @staticmethod
+    def parse(dat_record: DatRecord) -> Optional[tuple]:
+        if dat_record.identifier != 64250:
+            return None
+        buf = dat_record.record.record_buffer
+        identifier = struct.unpack("I", buf[8:12])[0]
+        object_identifier = struct.unpack_from("<I", buf, 0x0C)[0]
+        return (object_identifier, identifier, buf)

--- a/acd/record/sbregion.py
+++ b/acd/record/sbregion.py
@@ -2,6 +2,7 @@ import re
 import struct
 from dataclasses import dataclass
 from sqlite3 import Cursor
+from typing import Dict, Optional
 
 from acd.database.dbextract import DatRecord
 
@@ -14,7 +15,6 @@ class SbRegionRecord:
     dat_record: DatRecord
 
     def __post_init__(self):
-
         if self.dat_record.identifier == 64250:
             r = FafaSbregions.from_bytes(self.dat_record.record.record_buffer)
         else:
@@ -23,23 +23,16 @@ class SbRegionRecord:
         if r.header.language_type == "Rung NT" or r.header.language_type == "REGION NT":
             text = r.record_buffer.decode("utf-16-le").rstrip("\x00")
             self.text = self.replace_tag_references(text)
-
-            query: str = "INSERT INTO rungs VALUES (?, ?, ?)"
-            entry: tuple = (r.header.identifier, self.text, "")
-            self._cur.execute(query, entry)
+            self._cur.execute("INSERT INTO rungs VALUES (?, ?, ?)", (r.header.identifier, self.text, ""))
         elif r.header.language_type == "REGION AST":
             pass
         elif r.header.language_type == "REGION LE UID":
             uuid = struct.unpack("<I", r.record_buffer[-4:])[0]
             pass
-        else:
-            pass
 
     def replace_tag_references(self, sb_rec):
-        m = re.findall("@[A-Za-z0-9]*@", sb_rec)
-        for tag in m:
-            tag_no = tag[1:-1]
-            tag_id = int(tag_no, 16)
+        for tag in re.findall("@[A-Za-z0-9]*@", sb_rec):
+            tag_id = int(tag[1:-1], 16)
             self._cur.execute(
                 "SELECT object_id, comp_name FROM comps WHERE object_id=" + str(tag_id)
             )
@@ -48,3 +41,19 @@ class SbRegionRecord:
                 return sb_rec
             sb_rec = sb_rec.replace(tag, results[0][1])
         return sb_rec
+
+    @staticmethod
+    def parse(dat_record: DatRecord, name_lookup: Dict[int, str]) -> Optional[tuple]:
+        if dat_record.identifier != 64250:
+            return None
+        r = FafaSbregions.from_bytes(dat_record.record.record_buffer)
+        if r.header.language_type not in ("Rung NT", "REGION NT"):
+            return None
+        text = r.record_buffer.decode("utf-16-le").rstrip("\x00")
+        for tag in re.findall("@[A-Za-z0-9]*@", text):
+            tag_id = int(tag[1:-1], 16)
+            name = name_lookup.get(tag_id)
+            if name is None:
+                break
+            text = text.replace(tag, name)
+        return (r.header.identifier, text, "")


### PR DESCRIPTION
SQLite loading (58s → 550ms):
- Remove per-record COMMIT inside populate_region_map() loop
- Replace per-record execute() with batch executemany() for all four .Dat loaders (Comps, SbRegion, Comments, Nameless)
- Deduplicate Comps records by object_id in Python before insert, preserving last-occurrence semantics of original DELETE+INSERT
- Pre-build name_lookup dict from comps so SbRegion tag reference resolution (@HEX_ID@) uses memory instead of per-reference DB queries
- Add WAL journal mode and synchronous=OFF pragmas
- Add indexes on object_id, parent_id, parent_id+comp_name (comps), object_id (rungs), parent_id (region_map), parent (comments)

Object graph build (76s → 460ms):
- RoutineBuilder: replace N+1 rung queries with single JOIN
- TagBuilder: fall back to comp_name for tag name when extended_records 0x01 is absent (tags with count_record=1 have no extended attributes); data_type/radix still decoded from main_record as normal

Each record class gains a parse() staticmethod returning Optional[tuple] so callers can batch-collect tuples and use executemany(). The existing __post_init__ call path is preserved for backwards compatibility.