### PR TITLE
Add FileInfo.Dat HMAC for save_acd

### DIFF
--- a/acd/api.py
+++ b/acd/api.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from acd.integrity import (
     FILEINFO_LENGTH,
     compute_fileinfo,
+    detect_fileinfo_selector,
+    expected_key_length_for_selector,
     find_fileinfo_offset,
     get_fileinfo_key,
 )
@@ -56,14 +58,22 @@ def save_acd(project: RSLogix5000Content, output_path) -> None:
 
     If the project has had `acd.integrity.set_fileinfo_key(project, key)`
     called on it, the container's `FileInfo.Dat` is recomputed here so
-    that the Logix Designer SDK accepts the file. Without a registered
-    key, the container is written as-is (suitable for byte-equal
-    round-trips, but the SDK will reject any output where covered
-    streams were modified).
+    that the Logix Designer SDK accepts the file. The algorithm is
+    auto-selected by key length (32 bytes = modern Studio, 126 bytes =
+    older Studio); the key length must match the source ACD's
+    FileInfo.Dat selector or a ValueError is raised.
+
+    Without a registered key, the container is written as-is (suitable
+    for byte-equal round-trips, but the SDK will reject any output
+    where covered streams were modified).
 
     Args:
         project: Project loaded by load_acd().
         output_path: Destination .ACD file path.
+
+    Raises:
+        ValueError: if a key is registered whose length doesn't match
+            the source ACD's FileInfo.Dat selector.
     """
     container = build_acd_bytes(
         files=project._raw_files,
@@ -74,6 +84,15 @@ def save_acd(project: RSLogix5000Content, output_path) -> None:
     key = get_fileinfo_key(project)
     if key is not None:
         fi_offset = find_fileinfo_offset(container)
+        source_selector = detect_fileinfo_selector(container, fi_offset)
+        expected_key_len = expected_key_length_for_selector(source_selector)
+        if len(key) != expected_key_len:
+            raise ValueError(
+                f"ACD's FileInfo.Dat uses selector {source_selector:#06x} "
+                f"requiring a {expected_key_len}-byte key; the registered "
+                f"key is {len(key)} bytes. Register the correct key for "
+                f"this ACD's Studio version."
+            )
         new_fi = compute_fileinfo(container, fi_offset, key=key)
         container = (
             container[:fi_offset]

--- a/acd/api.py
+++ b/acd/api.py
@@ -7,9 +7,15 @@ from dataclasses import dataclass
 from os import PathLike
 from pathlib import Path
 
+from acd.integrity import (
+    FILEINFO_LENGTH,
+    compute_fileinfo,
+    find_fileinfo_offset,
+    get_fileinfo_key,
+)
 from acd.l5x.export_l5x import ExportL5x
 from acd.zip.unzip import Unzip
-from acd.zip.write_acd import write_acd
+from acd.zip.write_acd import build_acd_bytes, write_acd
 from acd.zip.write_dat import patch_sbregion_dat
 
 from acd.database.acd_database import AcdDatabase
@@ -48,16 +54,34 @@ def save_acd(project: RSLogix5000Content, output_path) -> None:
     The project must have been loaded via load_acd() or ExportL5x so that
     it carries _raw_files, _file_order, and _footer_unknown.
 
+    If the project has had `acd.integrity.set_fileinfo_key(project, key)`
+    called on it, the container's `FileInfo.Dat` is recomputed here so
+    that the Logix Designer SDK accepts the file. Without a registered
+    key, the container is written as-is (suitable for byte-equal
+    round-trips, but the SDK will reject any output where covered
+    streams were modified).
+
     Args:
         project: Project loaded by load_acd().
         output_path: Destination .ACD file path.
     """
-    write_acd(
+    container = build_acd_bytes(
         files=project._raw_files,
-        output_path=output_path,
         file_order=project._file_order,
         footer_unknown=project._footer_unknown,
     )
+
+    key = get_fileinfo_key(project)
+    if key is not None:
+        fi_offset = find_fileinfo_offset(container)
+        new_fi = compute_fileinfo(container, fi_offset, key=key)
+        container = (
+            container[:fi_offset]
+            + new_fi
+            + container[fi_offset + FILEINFO_LENGTH:]
+        )
+
+    Path(output_path).write_bytes(container)
 
 
 def patch_rungs(project: RSLogix5000Content, changes: dict) -> None:

--- a/acd/integrity/__init__.py
+++ b/acd/integrity/__init__.py
@@ -1,0 +1,34 @@
+"""ACD `FileInfo.Dat` integrity check.
+
+Public API:
+    pure functions (low-level):
+        compute_fileinfo(acd_bytes, fi_offset, *, key) -> 34-byte payload
+        verify_fileinfo(acd_bytes, fi_offset, *, key) -> bool
+        find_fileinfo_offset(acd_bytes) -> int
+
+    exceptions:
+        IntegrityKeyRequiredError
+
+The 32-byte HMAC key is NOT shipped with this library. Callers must
+supply it; the key is a per-Studio-version constant that users can
+extract from their legitimately-installed Studio 5000.
+"""
+from .fileinfo import (
+    FILEINFO_HEADER,
+    FILEINFO_LENGTH,
+    HMAC_KEY_LENGTH,
+    IntegrityKeyRequiredError,
+    compute_fileinfo,
+    find_fileinfo_offset,
+    verify_fileinfo,
+)
+
+__all__ = [
+    "FILEINFO_HEADER",
+    "FILEINFO_LENGTH",
+    "HMAC_KEY_LENGTH",
+    "IntegrityKeyRequiredError",
+    "compute_fileinfo",
+    "verify_fileinfo",
+    "find_fileinfo_offset",
+]

--- a/acd/integrity/__init__.py
+++ b/acd/integrity/__init__.py
@@ -6,6 +6,12 @@ Public API:
         verify_fileinfo(acd_bytes, fi_offset, *, key) -> bool
         find_fileinfo_offset(acd_bytes) -> int
 
+    project-level binding (high-level):
+        set_fileinfo_key(project, key) -> None
+        get_fileinfo_key(project) -> bytes | None
+        clear_fileinfo_key(project) -> None
+        verify_loaded_acd(project, acd_path) -> bool
+
     exceptions:
         IntegrityKeyRequiredError
 
@@ -22,6 +28,12 @@ from .fileinfo import (
     find_fileinfo_offset,
     verify_fileinfo,
 )
+from .project_key import (
+    clear_fileinfo_key,
+    get_fileinfo_key,
+    set_fileinfo_key,
+    verify_loaded_acd,
+)
 
 __all__ = [
     "FILEINFO_HEADER",
@@ -31,4 +43,8 @@ __all__ = [
     "compute_fileinfo",
     "verify_fileinfo",
     "find_fileinfo_offset",
+    "set_fileinfo_key",
+    "get_fileinfo_key",
+    "clear_fileinfo_key",
+    "verify_loaded_acd",
 ]

--- a/acd/integrity/__init__.py
+++ b/acd/integrity/__init__.py
@@ -5,6 +5,8 @@ Public API:
         compute_fileinfo(acd_bytes, fi_offset, *, key) -> 34-byte payload
         verify_fileinfo(acd_bytes, fi_offset, *, key) -> bool
         find_fileinfo_offset(acd_bytes) -> int
+        detect_fileinfo_selector(acd_bytes, fi_offset) -> int
+        expected_key_length_for_selector(selector) -> int
 
     project-level binding (high-level):
         set_fileinfo_key(project, key) -> None
@@ -14,17 +16,31 @@ Public API:
 
     exceptions:
         IntegrityKeyRequiredError
+        UnsupportedFileInfoSelectorError
 
-The 32-byte HMAC key is NOT shipped with this library. Callers must
-supply it; the key is a per-Studio-version constant that users can
-extract from their legitimately-installed Studio 5000.
+The algorithm is selected by key length:
+
+- 32-byte key  -> selector 02 00 (modern Studio).
+- 126-byte key -> selector 01 00 (older Studio).
+
+The HMAC key is NOT shipped with this library. Callers must supply
+it; the key is a per-Studio-version constant that users can extract
+from their legitimately-installed Studio 5000.
 """
 from .fileinfo import (
+    ACCEPTABLE_KEY_LENGTHS,
     FILEINFO_HEADER,
+    FILEINFO_HEADER_V1,
+    FILEINFO_HEADER_V2,
     FILEINFO_LENGTH,
     HMAC_KEY_LENGTH,
+    HMAC_KEY_LENGTH_V1,
+    HMAC_KEY_LENGTH_V2,
     IntegrityKeyRequiredError,
+    UnsupportedFileInfoSelectorError,
     compute_fileinfo,
+    detect_fileinfo_selector,
+    expected_key_length_for_selector,
     find_fileinfo_offset,
     verify_fileinfo,
 )
@@ -36,13 +52,21 @@ from .project_key import (
 )
 
 __all__ = [
+    "ACCEPTABLE_KEY_LENGTHS",
     "FILEINFO_HEADER",
+    "FILEINFO_HEADER_V1",
+    "FILEINFO_HEADER_V2",
     "FILEINFO_LENGTH",
     "HMAC_KEY_LENGTH",
+    "HMAC_KEY_LENGTH_V1",
+    "HMAC_KEY_LENGTH_V2",
     "IntegrityKeyRequiredError",
+    "UnsupportedFileInfoSelectorError",
     "compute_fileinfo",
     "verify_fileinfo",
     "find_fileinfo_offset",
+    "detect_fileinfo_selector",
+    "expected_key_length_for_selector",
     "set_fileinfo_key",
     "get_fileinfo_key",
     "clear_fileinfo_key",

--- a/acd/integrity/fileinfo.py
+++ b/acd/integrity/fileinfo.py
@@ -1,0 +1,165 @@
+"""ACD `FileInfo.Dat` integrity check (HMAC-SHA-256).
+
+Studio 5000's `.ACD` container embeds a 34-byte `FileInfo.Dat` stream
+whose contents validate the rest of the container on open. If you
+modify any HMAC-covered stream and write the container back without
+recomputing `FileInfo.Dat`, the Logix Designer SDK rejects the file
+with::
+
+    OperationFailedError: RxDbE_FILE_NOT_VALID
+    (HRESULT 0x80043D09)
+
+This module implements the algorithm. The 32-byte HMAC **key is not
+distributed with this library** — the caller must supply it as a
+keyword argument to `compute_fileinfo` / `verify_fileinfo`. The key
+is a per-Studio-version constant; users with a legitimate Studio
+5000 installation can extract it from their local copy.
+
+## Algorithm
+
+```text
+FileInfo.Dat = "02 00" || HMAC-SHA-256(KEY, sha256(file − FileInfo.Dat))
+```
+
+where `file − FileInfo.Dat` means "the entire ACD container with the
+34-byte FileInfo.Dat range elided." Both halves of the digest are
+straight SHA-256:
+
+1. `pre = sha256(acd[:fi_off] + acd[fi_off + 34:])`
+2. `post = hmac_sha256(KEY, pre)`
+3. `FileInfo.Dat = b"\\x02\\x00" + post`
+
+The leading two bytes `02 00` are an algorithm-selector header
+indicating SHA-256; they precede the 32-byte HMAC digest in the
+on-disk stream.
+
+## Verification
+
+Pure SHA-256 + HMAC-SHA-256; uses only `hashlib` + `hmac` stdlib.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import struct
+from typing import Union
+
+
+# 34-byte FileInfo.Dat = 2-byte algorithm selector + 32-byte HMAC-SHA-256 digest.
+FILEINFO_LENGTH = 34
+FILEINFO_HEADER = b"\x02\x00"  # algorithm-selector header for SHA-256
+HMAC_KEY_LENGTH = 32
+
+# ACD container record-table constants (matches acd/zip/write_acd.py format).
+_RECORD_SIZE = 528
+_FILENAME_FIELD_SIZE = 520
+_FOOTER_SIZE = 8
+
+
+class IntegrityKeyRequiredError(RuntimeError):
+    """Raised when `compute_fileinfo` is called without an HMAC key.
+
+    The 32-byte FileInfo.Dat HMAC key is not distributed with this
+    library. Pass it as a keyword argument (`key=...`) extracted from
+    a legitimately-installed Studio 5000.
+    """
+
+
+def compute_fileinfo(
+    acd_bytes: bytes,
+    fi_offset: int,
+    *,
+    key: Union[bytes, None],
+) -> bytes:
+    """Compute the 34-byte `FileInfo.Dat` payload for an ACD file.
+
+    Arguments:
+        acd_bytes: The full ACD container bytes, with the existing
+            `FileInfo.Dat` payload present at `fi_offset` (its content
+            doesn't matter — those 34 bytes are elided from the hash
+            input).
+        fi_offset: Byte offset of `FileInfo.Dat` within `acd_bytes`
+            (look it up via the container's record table — see
+            `find_fileinfo_offset`).
+        key: The 32-byte HMAC-SHA-256 key (keyword-only). Required.
+            Extract once from your locally-installed Studio 5000;
+            it's a per-version constant that you can stash in an
+            env var or local config file.
+
+    Returns:
+        34 bytes: `b"\\x02\\x00"` + 32-byte HMAC-SHA-256(key, sha256(file − FI)).
+
+    Raises:
+        IntegrityKeyRequiredError: if `key` is None.
+        ValueError: if `key` is the wrong length, or if `fi_offset` is
+            out of bounds.
+    """
+    if key is None:
+        raise IntegrityKeyRequiredError(
+            "FileInfo.Dat HMAC key required. The key is not distributed "
+            "with this library; extract it once from your locally-"
+            "installed Studio 5000 and pass it as the `key=` argument."
+        )
+    if len(key) != HMAC_KEY_LENGTH:
+        raise ValueError(
+            f"FileInfo HMAC key must be {HMAC_KEY_LENGTH} bytes; got {len(key)}"
+        )
+    if fi_offset < 0 or fi_offset + FILEINFO_LENGTH > len(acd_bytes):
+        raise ValueError(
+            f"fi_offset={fi_offset} out of bounds for "
+            f"{len(acd_bytes)}-byte ACD"
+        )
+
+    elided = acd_bytes[:fi_offset] + acd_bytes[fi_offset + FILEINFO_LENGTH:]
+    pre = hashlib.sha256(elided).digest()
+    post = hmac.new(key, pre, hashlib.sha256).digest()
+    return FILEINFO_HEADER + post
+
+
+def verify_fileinfo(
+    acd_bytes: bytes,
+    fi_offset: int,
+    *,
+    key: Union[bytes, None],
+) -> bool:
+    """Return True iff the 34-byte `FileInfo.Dat` at `fi_offset`
+    matches the bytes that `compute_fileinfo` would produce.
+
+    Same key requirement as `compute_fileinfo`.
+    """
+    expected = compute_fileinfo(acd_bytes, fi_offset, key=key)
+    actual = acd_bytes[fi_offset : fi_offset + FILEINFO_LENGTH]
+    return actual == expected
+
+
+def find_fileinfo_offset(acd_bytes: bytes) -> int:
+    """Scan the ACD container's record table to find FileInfo.Dat's
+    offset within the container.
+
+    The ACD container layout (see `acd/zip/write_acd.py`):
+
+    ```text
+    [file data blocks ...]
+    [file record table: 528 B × num_files]
+        [filename: UTF-16LE null-terminated, padded to 520 B]
+        [file_length: u32_le]
+        [file_offset: u32_le  -- absolute offset]
+    [footer: num_files u32_le + footer_unknown u32_le]
+    ```
+    """
+    if len(acd_bytes) < _FOOTER_SIZE:
+        raise ValueError("ACD too short for footer")
+    num_files, _ = struct.unpack_from("<II", acd_bytes, len(acd_bytes) - _FOOTER_SIZE)
+    rec_start = len(acd_bytes) - _FOOTER_SIZE - num_files * _RECORD_SIZE
+    if rec_start < 0:
+        raise ValueError("ACD record table out of bounds")
+    for i in range(num_files):
+        off = rec_start + i * _RECORD_SIZE
+        name_bytes = acd_bytes[off : off + _FILENAME_FIELD_SIZE]
+        name = name_bytes.decode("utf-16-le", errors="ignore").rstrip("\x00")
+        if name == "FileInfo.Dat":
+            _, foff = struct.unpack_from(
+                "<II", acd_bytes, off + _FILENAME_FIELD_SIZE
+            )
+            return foff
+    raise ValueError("FileInfo.Dat not found in record table")

--- a/acd/integrity/fileinfo.py
+++ b/acd/integrity/fileinfo.py
@@ -9,29 +9,33 @@ with::
     OperationFailedError: RxDbE_FILE_NOT_VALID
     (HRESULT 0x80043D09)
 
-This module implements the algorithm. The 32-byte HMAC **key is not
-distributed with this library** — the caller must supply it as a
-keyword argument to `compute_fileinfo` / `verify_fileinfo`. The key
-is a per-Studio-version constant; users with a legitimate Studio
-5000 installation can extract it from their local copy.
+This module supports both algorithm variants observed across Studio
+5000 versions. Each `FileInfo.Dat` carries a 2-byte selector header
+that identifies the construction; the remaining 32 bytes are an
+HMAC-SHA-256 digest.
 
-## Algorithm
+| Selector | HMAC input            | Key length |
+|----------|-----------------------|-----------|
+| `01 00`  | `file - FileInfo.Dat` | 126 bytes |
+| `02 00`  | `sha256(file - FI)`   | 32 bytes  |
 
-```text
-FileInfo.Dat = "02 00" || HMAC-SHA-256(KEY, sha256(file − FileInfo.Dat))
-```
+The HMAC key is **not distributed with this library** -- the caller
+must supply it as a keyword argument. The key is a per-Studio-version
+constant; users with a legitimate Studio installation can extract it
+from their local copy.
 
-where `file − FileInfo.Dat` means "the entire ACD container with the
-34-byte FileInfo.Dat range elided." Both halves of the digest are
-straight SHA-256:
+## Algorithm dispatch
 
-1. `pre = sha256(acd[:fi_off] + acd[fi_off + 34:])`
-2. `post = hmac_sha256(KEY, pre)`
-3. `FileInfo.Dat = b"\\x02\\x00" + post`
+This module picks the algorithm based on the **key length** supplied:
 
-The leading two bytes `02 00` are an algorithm-selector header
-indicating SHA-256; they precede the 32-byte HMAC digest in the
-on-disk stream.
+- A 32-byte key produces a selector `02 00` FileInfo.Dat.
+- A 126-byte key produces a selector `01 00` FileInfo.Dat.
+- Any other key length raises ValueError.
+
+Callers don't choose the selector explicitly; the key length
+unambiguously identifies which Studio version's algorithm to use.
+Use `detect_fileinfo_selector` to read the selector from an existing
+file when you need to choose between multiple keys you hold.
 
 ## Verification
 
@@ -42,13 +46,26 @@ from __future__ import annotations
 import hashlib
 import hmac
 import struct
-from typing import Union
+from typing import Tuple, Union
 
 
-# 34-byte FileInfo.Dat = 2-byte algorithm selector + 32-byte HMAC-SHA-256 digest.
+# FileInfo.Dat layout: 2-byte selector + 32-byte HMAC-SHA-256 digest.
 FILEINFO_LENGTH = 34
-FILEINFO_HEADER = b"\x02\x00"  # algorithm-selector header for SHA-256
-HMAC_KEY_LENGTH = 32
+
+# Per-version constants.
+# Selector 1: older Studio versions.
+FILEINFO_HEADER_V1 = b"\x01\x00"
+HMAC_KEY_LENGTH_V1 = 126
+# Selector 2: modern Studio versions.
+FILEINFO_HEADER_V2 = b"\x02\x00"
+HMAC_KEY_LENGTH_V2 = 32
+
+# Back-compat aliases (selector 2 was the only one historically named here).
+FILEINFO_HEADER = FILEINFO_HEADER_V2
+HMAC_KEY_LENGTH = HMAC_KEY_LENGTH_V2
+
+# Tuple of all key lengths this library accepts.
+ACCEPTABLE_KEY_LENGTHS = (HMAC_KEY_LENGTH_V2, HMAC_KEY_LENGTH_V1)
 
 # ACD container record-table constants (matches acd/zip/write_acd.py format).
 _RECORD_SIZE = 528
@@ -59,10 +76,39 @@ _FOOTER_SIZE = 8
 class IntegrityKeyRequiredError(RuntimeError):
     """Raised when `compute_fileinfo` is called without an HMAC key.
 
-    The 32-byte FileInfo.Dat HMAC key is not distributed with this
-    library. Pass it as a keyword argument (`key=...`) extracted from
-    a legitimately-installed Studio 5000.
+    The FileInfo.Dat HMAC key is not distributed with this library.
+    Pass it as a keyword argument (`key=...`) extracted from a
+    legitimately-installed Studio 5000.
     """
+
+
+class UnsupportedFileInfoSelectorError(ValueError):
+    """Raised when FileInfo.Dat uses a selector this library doesn't
+    implement.
+
+    Two selectors are recognised: `01 00` (older Studio) and `02 00`
+    (modern Studio). Any other selector indicates either a corrupt
+    container or an algorithm not implemented here.
+    """
+
+
+def _algorithm_for_key(key: bytes) -> Tuple[bytes, "callable"]:
+    """Return (selector_header, prep_fn) for an HMAC key.
+
+    `prep_fn(elided_bytes)` returns the value HMAC will sign:
+
+    - Selector 1 (126-byte key): identity -- HMAC over `file - FI`.
+    - Selector 2 (32-byte key): SHA-256 -- HMAC over `sha256(file - FI)`.
+    """
+    if len(key) == HMAC_KEY_LENGTH_V2:
+        return FILEINFO_HEADER_V2, lambda elided: hashlib.sha256(elided).digest()
+    if len(key) == HMAC_KEY_LENGTH_V1:
+        return FILEINFO_HEADER_V1, lambda elided: elided
+    raise ValueError(
+        f"FileInfo HMAC key must be {HMAC_KEY_LENGTH_V2} bytes "
+        f"(modern Studio) or {HMAC_KEY_LENGTH_V1} bytes (older Studio); "
+        f"got {len(key)}"
+    )
 
 
 def compute_fileinfo(
@@ -73,26 +119,30 @@ def compute_fileinfo(
 ) -> bytes:
     """Compute the 34-byte `FileInfo.Dat` payload for an ACD file.
 
+    The algorithm is selected by `key` length:
+
+    - A 32-byte key produces a selector `02 00` FileInfo.Dat
+      (modern Studio): `HMAC-SHA-256(key, sha256(file - FI))`.
+    - A 126-byte key produces a selector `01 00` FileInfo.Dat
+      (older Studio): `HMAC-SHA-256(key, file - FI)`.
+
     Arguments:
         acd_bytes: The full ACD container bytes, with the existing
             `FileInfo.Dat` payload present at `fi_offset` (its content
-            doesn't matter — those 34 bytes are elided from the hash
+            doesn't matter -- those 34 bytes are elided from the hash
             input).
         fi_offset: Byte offset of `FileInfo.Dat` within `acd_bytes`
-            (look it up via the container's record table — see
-            `find_fileinfo_offset`).
-        key: The 32-byte HMAC-SHA-256 key (keyword-only). Required.
-            Extract once from your locally-installed Studio 5000;
-            it's a per-version constant that you can stash in an
-            env var or local config file.
+            (look it up via `find_fileinfo_offset`).
+        key: The HMAC-SHA-256 key (keyword-only). Required. Must be
+            either 32 bytes (modern) or 126 bytes (older).
 
     Returns:
-        34 bytes: `b"\\x02\\x00"` + 32-byte HMAC-SHA-256(key, sha256(file − FI)).
+        34 bytes: 2-byte algorithm-selector header + 32-byte digest.
 
     Raises:
         IntegrityKeyRequiredError: if `key` is None.
-        ValueError: if `key` is the wrong length, or if `fi_offset` is
-            out of bounds.
+        ValueError: if `key` is not an accepted length, or if
+            `fi_offset` is out of bounds.
     """
     if key is None:
         raise IntegrityKeyRequiredError(
@@ -100,10 +150,7 @@ def compute_fileinfo(
             "with this library; extract it once from your locally-"
             "installed Studio 5000 and pass it as the `key=` argument."
         )
-    if len(key) != HMAC_KEY_LENGTH:
-        raise ValueError(
-            f"FileInfo HMAC key must be {HMAC_KEY_LENGTH} bytes; got {len(key)}"
-        )
+    header, prep = _algorithm_for_key(key)
     if fi_offset < 0 or fi_offset + FILEINFO_LENGTH > len(acd_bytes):
         raise ValueError(
             f"fi_offset={fi_offset} out of bounds for "
@@ -111,9 +158,9 @@ def compute_fileinfo(
         )
 
     elided = acd_bytes[:fi_offset] + acd_bytes[fi_offset + FILEINFO_LENGTH:]
-    pre = hashlib.sha256(elided).digest()
-    post = hmac.new(key, pre, hashlib.sha256).digest()
-    return FILEINFO_HEADER + post
+    hmac_input = prep(elided)
+    digest = hmac.new(key, hmac_input, hashlib.sha256).digest()
+    return header + digest
 
 
 def verify_fileinfo(
@@ -125,11 +172,55 @@ def verify_fileinfo(
     """Return True iff the 34-byte `FileInfo.Dat` at `fi_offset`
     matches the bytes that `compute_fileinfo` would produce.
 
-    Same key requirement as `compute_fileinfo`.
+    The algorithm is auto-selected by key length. Same key requirement
+    as `compute_fileinfo`.
     """
     expected = compute_fileinfo(acd_bytes, fi_offset, key=key)
     actual = acd_bytes[fi_offset : fi_offset + FILEINFO_LENGTH]
     return actual == expected
+
+
+def detect_fileinfo_selector(acd_bytes: bytes, fi_offset: int) -> int:
+    """Return the algorithm-selector value (1 or 2) read from
+    `FileInfo.Dat` at `fi_offset`.
+
+    Reads the 2-byte little-endian selector header. Use this when
+    you don't know which Studio version produced a given ACD and
+    want to look up the right key to register.
+
+    Raises:
+        ValueError: if `fi_offset` is out of bounds.
+        UnsupportedFileInfoSelectorError: if the selector isn't a
+            known value.
+    """
+    if fi_offset < 0 or fi_offset + 2 > len(acd_bytes):
+        raise ValueError(
+            f"fi_offset={fi_offset} out of bounds for "
+            f"{len(acd_bytes)}-byte ACD"
+        )
+    selector = acd_bytes[fi_offset] | (acd_bytes[fi_offset + 1] << 8)
+    if selector not in (1, 2):
+        raise UnsupportedFileInfoSelectorError(
+            f"FileInfo.Dat selector {selector:#06x} not supported; "
+            f"this library implements selectors 0x0001 and 0x0002."
+        )
+    return selector
+
+
+def expected_key_length_for_selector(selector: int) -> int:
+    """Return the key length (in bytes) required for a given selector.
+
+    Raises:
+        UnsupportedFileInfoSelectorError: if the selector isn't known.
+    """
+    if selector == 2:
+        return HMAC_KEY_LENGTH_V2
+    if selector == 1:
+        return HMAC_KEY_LENGTH_V1
+    raise UnsupportedFileInfoSelectorError(
+        f"FileInfo.Dat selector {selector:#06x} not supported; "
+        f"this library implements selectors 0x0001 and 0x0002."
+    )
 
 
 def find_fileinfo_offset(acd_bytes: bytes) -> int:
@@ -140,7 +231,7 @@ def find_fileinfo_offset(acd_bytes: bytes) -> int:
 
     ```text
     [file data blocks ...]
-    [file record table: 528 B × num_files]
+    [file record table: 528 B * num_files]
         [filename: UTF-16LE null-terminated, padded to 520 B]
         [file_length: u32_le]
         [file_offset: u32_le  -- absolute offset]

--- a/acd/integrity/project_key.py
+++ b/acd/integrity/project_key.py
@@ -1,10 +1,16 @@
 """Project-level binding for the FileInfo.Dat HMAC key.
 
-The 32-byte HMAC-SHA-256 key is a per-Studio-version constant that
-this library does not ship. The caller extracts it once from their
-legitimate Studio 5000 install, then registers it on a loaded
-project via `set_fileinfo_key`. After that, the save pipeline picks
-it up automatically when it needs to recompute `FileInfo.Dat`.
+The HMAC-SHA-256 key is a per-Studio-version constant that this
+library does not ship. The caller extracts it once from their
+legitimate Studio 5000 install, then registers it on a loaded project
+via `set_fileinfo_key`. After that, the save pipeline picks it up
+automatically when it needs to recompute `FileInfo.Dat`.
+
+Two key lengths are accepted; the library dispatches to the matching
+algorithm by key length:
+
+- 32-byte key  -> selector `02 00` (modern Studio).
+- 126-byte key -> selector `01 00` (older Studio).
 
 Usage:
 
@@ -25,7 +31,7 @@ from __future__ import annotations
 from typing import Optional
 
 from .fileinfo import (
-    HMAC_KEY_LENGTH,
+    ACCEPTABLE_KEY_LENGTHS,
     IntegrityKeyRequiredError,
     find_fileinfo_offset,
     verify_fileinfo,
@@ -36,7 +42,12 @@ _KEY_ATTR = "_fileinfo_key"
 
 
 def set_fileinfo_key(project, key: bytes) -> None:
-    """Register the 32-byte FileInfo.Dat HMAC-SHA-256 key on a project.
+    """Register the FileInfo.Dat HMAC-SHA-256 key on a project.
+
+    The key length picks the algorithm:
+
+    - 32 bytes  -> modern Studio (`02 00` selector).
+    - 126 bytes -> older Studio (`01 00` selector).
 
     After this call, save-side machinery (and `verify_loaded_acd`)
     can recompute or verify `FileInfo.Dat` without the caller having
@@ -46,20 +57,22 @@ def set_fileinfo_key(project, key: bytes) -> None:
         project: An object returned by `acd.api.load_acd` (or any
             `RSLogix5000Content` instance). The key is attached as a
             private attribute on this object only.
-        key: The 32-byte HMAC-SHA-256 key.
+        key: The HMAC-SHA-256 key, 32 or 126 bytes.
 
     Raises:
         TypeError: if `key` is not a bytes-like object.
-        ValueError: if `key` is not exactly 32 bytes.
+        ValueError: if `key` is not an accepted length.
     """
     if not isinstance(key, (bytes, bytearray, memoryview)):
         raise TypeError(
             f"key must be bytes-like, got {type(key).__name__}"
         )
     key_bytes = bytes(key)
-    if len(key_bytes) != HMAC_KEY_LENGTH:
+    if len(key_bytes) not in ACCEPTABLE_KEY_LENGTHS:
         raise ValueError(
-            f"key must be {HMAC_KEY_LENGTH} bytes; got {len(key_bytes)}"
+            f"key must be one of {ACCEPTABLE_KEY_LENGTHS} bytes "
+            f"(32 = modern Studio, 126 = older Studio); "
+            f"got {len(key_bytes)}"
         )
     setattr(project, _KEY_ATTR, key_bytes)
 
@@ -68,8 +81,8 @@ def get_fileinfo_key(project) -> Optional[bytes]:
     """Return the key set via `set_fileinfo_key`, or None if unset.
 
     Returns:
-        The 32-byte key, or `None` if `set_fileinfo_key` was never
-        called on this project.
+        The registered key bytes, or `None` if `set_fileinfo_key`
+        was never called on this project.
     """
     return getattr(project, _KEY_ATTR, None)
 
@@ -90,7 +103,8 @@ def verify_loaded_acd(project, acd_path) -> bool:
 
     Reads the bytes at `acd_path`, locates `FileInfo.Dat` via the
     container's record table, and recomputes the HMAC under the key
-    set via `set_fileinfo_key`.
+    set via `set_fileinfo_key`. The algorithm is auto-selected by
+    key length.
 
     Arguments:
         project: A project that has had `set_fileinfo_key` called on it.

--- a/acd/integrity/project_key.py
+++ b/acd/integrity/project_key.py
@@ -1,0 +1,116 @@
+"""Project-level binding for the FileInfo.Dat HMAC key.
+
+The 32-byte HMAC-SHA-256 key is a per-Studio-version constant that
+this library does not ship. The caller extracts it once from their
+legitimate Studio 5000 install, then registers it on a loaded
+project via `set_fileinfo_key`. After that, the save pipeline picks
+it up automatically when it needs to recompute `FileInfo.Dat`.
+
+Usage:
+
+    from acd.api import load_acd, save_acd
+    from acd.integrity import set_fileinfo_key
+
+    project = load_acd("input.ACD")
+    set_fileinfo_key(project, bytes.fromhex(os.environ["ACD_FILEINFO_KEY"]))
+    # ... mutate project ...
+    save_acd(project, "output.ACD")   # FileInfo.Dat recomputed using the key
+
+The key is stored as a private attribute (`_fileinfo_key`) on the
+project object. It never leaves the in-memory project; this library
+does not log it, persist it, or send it anywhere.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from .fileinfo import (
+    HMAC_KEY_LENGTH,
+    IntegrityKeyRequiredError,
+    find_fileinfo_offset,
+    verify_fileinfo,
+)
+
+
+_KEY_ATTR = "_fileinfo_key"
+
+
+def set_fileinfo_key(project, key: bytes) -> None:
+    """Register the 32-byte FileInfo.Dat HMAC-SHA-256 key on a project.
+
+    After this call, save-side machinery (and `verify_loaded_acd`)
+    can recompute or verify `FileInfo.Dat` without the caller having
+    to thread the key through every API.
+
+    Arguments:
+        project: An object returned by `acd.api.load_acd` (or any
+            `RSLogix5000Content` instance). The key is attached as a
+            private attribute on this object only.
+        key: The 32-byte HMAC-SHA-256 key.
+
+    Raises:
+        TypeError: if `key` is not a bytes-like object.
+        ValueError: if `key` is not exactly 32 bytes.
+    """
+    if not isinstance(key, (bytes, bytearray, memoryview)):
+        raise TypeError(
+            f"key must be bytes-like, got {type(key).__name__}"
+        )
+    key_bytes = bytes(key)
+    if len(key_bytes) != HMAC_KEY_LENGTH:
+        raise ValueError(
+            f"key must be {HMAC_KEY_LENGTH} bytes; got {len(key_bytes)}"
+        )
+    setattr(project, _KEY_ATTR, key_bytes)
+
+
+def get_fileinfo_key(project) -> Optional[bytes]:
+    """Return the key set via `set_fileinfo_key`, or None if unset.
+
+    Returns:
+        The 32-byte key, or `None` if `set_fileinfo_key` was never
+        called on this project.
+    """
+    return getattr(project, _KEY_ATTR, None)
+
+
+def clear_fileinfo_key(project) -> None:
+    """Remove the FileInfo.Dat key from a project, if set.
+
+    Use this if you want to ensure subsequent save operations fail
+    with `IntegrityKeyRequiredError` rather than silently using a
+    stale key.
+    """
+    if hasattr(project, _KEY_ATTR):
+        delattr(project, _KEY_ATTR)
+
+
+def verify_loaded_acd(project, acd_path) -> bool:
+    """Verify the on-disk ACD's FileInfo.Dat using the project's key.
+
+    Reads the bytes at `acd_path`, locates `FileInfo.Dat` via the
+    container's record table, and recomputes the HMAC under the key
+    set via `set_fileinfo_key`.
+
+    Arguments:
+        project: A project that has had `set_fileinfo_key` called on it.
+        acd_path: Path to the .ACD file to verify.
+
+    Returns:
+        True iff the file's `FileInfo.Dat` matches the computed value.
+
+    Raises:
+        IntegrityKeyRequiredError: if no key was set on the project.
+        ValueError: if `acd_path` is not a valid ACD container.
+    """
+    key = get_fileinfo_key(project)
+    if key is None:
+        raise IntegrityKeyRequiredError(
+            "No FileInfo.Dat HMAC key set on this project. Call "
+            "set_fileinfo_key(project, key) first; see "
+            "acd.integrity for details."
+        )
+    with open(acd_path, "rb") as fh:
+        acd = fh.read()
+    fi_off = find_fileinfo_offset(acd)
+    return verify_fileinfo(acd, fi_off, key=key)

--- a/acd/zip/write_acd.py
+++ b/acd/zip/write_acd.py
@@ -19,20 +19,21 @@ from pathlib import Path
 from typing import Dict, List
 
 
-def write_acd(
+def build_acd_bytes(
     files: Dict[str, bytes],
-    output_path,
     file_order: List[str] = None,
     footer_unknown: int = 2,
-) -> None:
-    """Pack files into a Rockwell ACD container.
+) -> bytes:
+    """Pack files into a Rockwell ACD container, returning the bytes.
 
     Args:
         files: Mapping of filename → raw bytes.
-        output_path: Destination .ACD path.
         file_order: Filenames in desired write order.  Defaults to files.keys().
         footer_unknown: The second u32 in the ACD footer.  Preserve the value
             from the original file (accessible via Unzip.header._unknown_two).
+
+    Returns:
+        The full ACD container as a bytes object.
     """
     if file_order is None:
         file_order = list(files.keys())
@@ -58,4 +59,26 @@ def write_acd(
     # Footer
     output.extend(struct.pack("<II", len(file_records), footer_unknown))
 
-    Path(output_path).write_bytes(bytes(output))
+    return bytes(output)
+
+
+def write_acd(
+    files: Dict[str, bytes],
+    output_path,
+    file_order: List[str] = None,
+    footer_unknown: int = 2,
+) -> None:
+    """Pack files into a Rockwell ACD container and write to disk.
+
+    Thin wrapper around `build_acd_bytes`; preserved as the public API.
+
+    Args:
+        files: Mapping of filename → raw bytes.
+        output_path: Destination .ACD path.
+        file_order: Filenames in desired write order.  Defaults to files.keys().
+        footer_unknown: The second u32 in the ACD footer.  Preserve the value
+            from the original file (accessible via Unzip.header._unknown_two).
+    """
+    Path(output_path).write_bytes(
+        build_acd_bytes(files, file_order=file_order, footer_unknown=footer_unknown)
+    )

--- a/test/test_integrity_fileinfo.py
+++ b/test/test_integrity_fileinfo.py
@@ -2,30 +2,51 @@
 
 These tests cover:
 - Algorithm structure (deterministic output, sensitive to key changes)
-- Error paths (no key, wrong-length key, out-of-bounds offset)
-- find_fileinfo_offset against a real ACD's record table
+- Both selectors -- 02 00 (modern, 32-byte key) and 01 00 (older,
+  126-byte key) -- via parametrized tests
+- Error paths (no key, wrong-length key, out-of-bounds offset,
+  unknown on-disk selector)
+- find_fileinfo_offset / detect_fileinfo_selector against a real ACD
 
-A real-key verification test runs only when the `ACD_FILEINFO_KEY`
-env var is set (64-char hex string). Users with a legitimate Studio
-5000 install can extract their key and set the env var to run it;
-CI / strangers without the key skip it.
+Both selectors (v1 and v2) are exercised by the structural and
+round-trip tests above using arbitrary test keys. A v2 real-key
+end-to-end check additionally runs when the `ACD_FILEINFO_KEY` env
+var is set (64-char hex = 32-byte v2 key), verifying the bundled
+CuteLogix.ACD fixture; it is skipped otherwise. There is no
+equivalent v1 real-key test because the repo doesn't ship a
+v21-vintage sample ACD fixture.
 """
+import hashlib
+import hmac
 import os
 
 import pytest
 
 from acd.integrity import (
-    FILEINFO_HEADER,
+    ACCEPTABLE_KEY_LENGTHS,
+    FILEINFO_HEADER_V1,
+    FILEINFO_HEADER_V2,
     FILEINFO_LENGTH,
     HMAC_KEY_LENGTH,
+    HMAC_KEY_LENGTH_V1,
+    HMAC_KEY_LENGTH_V2,
     IntegrityKeyRequiredError,
+    UnsupportedFileInfoSelectorError,
     compute_fileinfo,
+    detect_fileinfo_selector,
+    expected_key_length_for_selector,
     find_fileinfo_offset,
     verify_fileinfo,
 )
 
 
 CUTELOGIX = os.path.join("..", "resources", "CuteLogix.ACD")
+
+# Parametrize over both algorithms: (key_length, expected_header).
+ALGORITHMS = [
+    pytest.param(HMAC_KEY_LENGTH_V2, FILEINFO_HEADER_V2, id="v2-32-byte-modern"),
+    pytest.param(HMAC_KEY_LENGTH_V1, FILEINFO_HEADER_V1, id="v1-126-byte-older"),
+]
 
 
 def _read_acd():
@@ -44,88 +65,194 @@ def test_no_key_raises():
 
 
 def test_wrong_length_key_raises():
-    """A key that isn't exactly 32 bytes raises ValueError."""
+    """A key whose length isn't in ACCEPTABLE_KEY_LENGTHS raises ValueError.
+
+    Note that 32 and 126 are *accepted* lengths; everything else is bad."""
     acd = _read_acd()
     fi_off = find_fileinfo_offset(acd)
-    for bad in (b"", b"x" * 16, b"y" * 31, b"z" * 33, b"w" * 64):
+    # Anything that is NOT in ACCEPTABLE_KEY_LENGTHS:
+    bad_lengths = (0, 1, 16, 31, 33, 64, 125, 127, 128)
+    for n in bad_lengths:
+        assert n not in ACCEPTABLE_KEY_LENGTHS, (
+            f"Test bug: {n} is in ACCEPTABLE_KEY_LENGTHS"
+        )
         with pytest.raises(ValueError):
-            compute_fileinfo(acd, fi_off, key=bad)
+            compute_fileinfo(acd, fi_off, key=b"\x00" * n)
 
 
-def test_compute_deterministic():
+@pytest.mark.parametrize("key_len,header", ALGORITHMS)
+def test_compute_deterministic(key_len, header):
     """Calling compute_fileinfo twice with the same inputs gives
-    identical output."""
+    identical output, of length FILEINFO_LENGTH, starting with the
+    selector header that matches the key length."""
     acd = _read_acd()
     fi_off = find_fileinfo_offset(acd)
-    key = b"\x00" * HMAC_KEY_LENGTH
+    key = b"\x00" * key_len
     first = compute_fileinfo(acd, fi_off, key=key)
     second = compute_fileinfo(acd, fi_off, key=key)
     assert first == second
     assert len(first) == FILEINFO_LENGTH
-    assert first.startswith(FILEINFO_HEADER)
+    assert first[:2] == header
 
 
-def test_compute_changes_with_key():
-    """Different keys produce different HMAC outputs."""
+@pytest.mark.parametrize("key_len,header", ALGORITHMS)
+def test_compute_changes_with_key(key_len, header):
+    """Different keys of the same length produce different HMAC outputs;
+    selector header stays the same."""
     acd = _read_acd()
     fi_off = find_fileinfo_offset(acd)
-    fi_zero = compute_fileinfo(acd, fi_off, key=b"\x00" * HMAC_KEY_LENGTH)
-    fi_ones = compute_fileinfo(acd, fi_off, key=b"\xff" * HMAC_KEY_LENGTH)
+    fi_zero = compute_fileinfo(acd, fi_off, key=b"\x00" * key_len)
+    fi_ones = compute_fileinfo(acd, fi_off, key=b"\xff" * key_len)
     assert fi_zero != fi_ones
-    # Both still start with the algorithm-selector header.
-    assert fi_zero[:2] == FILEINFO_HEADER
-    assert fi_ones[:2] == FILEINFO_HEADER
+    assert fi_zero[:2] == header
+    assert fi_ones[:2] == header
 
 
-def test_verify_round_trips_with_same_key():
+@pytest.mark.parametrize("key_len,header", ALGORITHMS)
+def test_verify_round_trips_with_same_key(key_len, header):
     """If we patch in the bytes compute_fileinfo emits, verify_fileinfo
     returns True under the same key."""
     acd = bytearray(_read_acd())
     fi_off = find_fileinfo_offset(bytes(acd))
-    key = b"\x42" * HMAC_KEY_LENGTH
+    key = b"\x42" * key_len
     new_fi = compute_fileinfo(bytes(acd), fi_off, key=key)
+    assert new_fi[:2] == header
     acd[fi_off : fi_off + FILEINFO_LENGTH] = new_fi
     assert verify_fileinfo(bytes(acd), fi_off, key=key)
 
 
-def test_verify_fails_with_wrong_key():
+@pytest.mark.parametrize("key_len,header", ALGORITHMS)
+def test_verify_fails_with_wrong_key(key_len, header):
     """verify_fileinfo returns False under a key different from the
-    one used to compute the FileInfo."""
+    one used to compute the FileInfo (same length, different bytes)."""
     acd = bytearray(_read_acd())
     fi_off = find_fileinfo_offset(bytes(acd))
-    key_a = b"\x01" * HMAC_KEY_LENGTH
-    key_b = b"\x02" * HMAC_KEY_LENGTH
+    key_a = b"\x01" * key_len
+    key_b = b"\x02" * key_len
     new_fi = compute_fileinfo(bytes(acd), fi_off, key=key_a)
     acd[fi_off : fi_off + FILEINFO_LENGTH] = new_fi
     assert not verify_fileinfo(bytes(acd), fi_off, key=key_b)
 
 
-def test_find_fileinfo_offset_in_cutelogix():
-    """The record-table scan locates FileInfo.Dat in CuteLogix.ACD."""
+def test_v2_uses_pre_hash_sha256():
+    """The 32-byte (modern) algorithm HMACs sha256(file - FI), not the
+    raw bytes. Verify by computing the expected value manually."""
     acd = _read_acd()
     fi_off = find_fileinfo_offset(acd)
-    # Verify the byte range is plausible: should be within the file,
-    # and the stream content should start with the 02 00 algorithm
-    # selector header.
+    key = b"\xaa" * HMAC_KEY_LENGTH_V2
+    elided = acd[:fi_off] + acd[fi_off + FILEINFO_LENGTH:]
+    pre = hashlib.sha256(elided).digest()
+    expected_digest = hmac.new(key, pre, hashlib.sha256).digest()
+    result = compute_fileinfo(acd, fi_off, key=key)
+    assert result == FILEINFO_HEADER_V2 + expected_digest
+
+
+def test_v1_uses_no_pre_hash():
+    """The 126-byte (older) algorithm HMACs `file - FI` directly with
+    no SHA-256 pre-hash. Verify by computing the expected value
+    manually."""
+    acd = _read_acd()
+    fi_off = find_fileinfo_offset(acd)
+    key = b"\xbb" * HMAC_KEY_LENGTH_V1
+    elided = acd[:fi_off] + acd[fi_off + FILEINFO_LENGTH:]
+    expected_digest = hmac.new(key, elided, hashlib.sha256).digest()
+    result = compute_fileinfo(acd, fi_off, key=key)
+    assert result == FILEINFO_HEADER_V1 + expected_digest
+
+
+def test_v1_and_v2_produce_different_outputs():
+    """Same elided file, different key length -> different selector
+    AND different digest (because the HMAC inputs differ structurally)."""
+    acd = _read_acd()
+    fi_off = find_fileinfo_offset(acd)
+    fi_v2 = compute_fileinfo(acd, fi_off, key=b"\xcc" * HMAC_KEY_LENGTH_V2)
+    fi_v1 = compute_fileinfo(acd, fi_off, key=b"\xcc" * HMAC_KEY_LENGTH_V1)
+    assert fi_v2[:2] == FILEINFO_HEADER_V2
+    assert fi_v1[:2] == FILEINFO_HEADER_V1
+    assert fi_v2[2:] != fi_v1[2:]
+
+
+def test_find_fileinfo_offset_in_cutelogix():
+    """The record-table scan locates FileInfo.Dat in CuteLogix.ACD.
+    CuteLogix is modern (selector 02 00)."""
+    acd = _read_acd()
+    fi_off = find_fileinfo_offset(acd)
     assert 0 < fi_off < len(acd) - FILEINFO_LENGTH
-    assert acd[fi_off : fi_off + 2] == FILEINFO_HEADER
+    assert acd[fi_off : fi_off + 2] == FILEINFO_HEADER_V2
 
 
-def test_out_of_bounds_offset_raises():
+def test_detect_fileinfo_selector_modern():
+    """detect_fileinfo_selector returns 2 for a modern ACD's FileInfo.Dat."""
+    acd = _read_acd()
+    fi_off = find_fileinfo_offset(acd)
+    assert detect_fileinfo_selector(acd, fi_off) == 2
+
+
+def test_detect_fileinfo_selector_older():
+    """detect_fileinfo_selector returns 1 when the on-disk header is 01 00."""
+    acd = bytearray(_read_acd())
+    fi_off = find_fileinfo_offset(bytes(acd))
+    # Force the header to 01 00 (the rest of the FI doesn't matter for detection).
+    acd[fi_off : fi_off + 2] = FILEINFO_HEADER_V1
+    assert detect_fileinfo_selector(bytes(acd), fi_off) == 1
+
+
+def test_detect_fileinfo_selector_unknown_raises():
+    """An on-disk header that isn't 01 00 or 02 00 raises
+    UnsupportedFileInfoSelectorError."""
+    acd = bytearray(_read_acd())
+    fi_off = find_fileinfo_offset(bytes(acd))
+    acd[fi_off : fi_off + 2] = b"\x99\x99"
+    with pytest.raises(UnsupportedFileInfoSelectorError):
+        detect_fileinfo_selector(bytes(acd), fi_off)
+
+
+def test_detect_fileinfo_selector_out_of_bounds():
+    """Out-of-bounds offset raises ValueError, NOT
+    UnsupportedFileInfoSelectorError."""
+    acd = _read_acd()
+    with pytest.raises(ValueError):
+        detect_fileinfo_selector(acd, -1)
+    with pytest.raises(ValueError):
+        detect_fileinfo_selector(acd, len(acd) - 1)
+
+
+def test_expected_key_length_for_selector():
+    """Lookup helper maps selector -> required key length."""
+    assert expected_key_length_for_selector(2) == HMAC_KEY_LENGTH_V2
+    assert expected_key_length_for_selector(1) == HMAC_KEY_LENGTH_V1
+    with pytest.raises(UnsupportedFileInfoSelectorError):
+        expected_key_length_for_selector(3)
+
+
+@pytest.mark.parametrize("key_len,header", ALGORITHMS)
+def test_out_of_bounds_offset_raises(key_len, header):
     """A bogus fi_offset raises ValueError."""
     acd = _read_acd()
-    key = b"\x00" * HMAC_KEY_LENGTH
+    key = b"\x00" * key_len
     with pytest.raises(ValueError):
         compute_fileinfo(acd, -1, key=key)
     with pytest.raises(ValueError):
         compute_fileinfo(acd, len(acd) - 10, key=key)
 
 
-# Real-key test — only runs if user supplies the key via env var.
+def test_back_compat_aliases():
+    """Back-compat aliases still resolve (HMAC_KEY_LENGTH = v2 length,
+    FILEINFO_HEADER = v2 header)."""
+    from acd.integrity import FILEINFO_HEADER
+    assert HMAC_KEY_LENGTH == HMAC_KEY_LENGTH_V2 == 32
+    assert FILEINFO_HEADER == FILEINFO_HEADER_V2 == b"\x02\x00"
+
+
+# Real-key v2 end-to-end check; gated on the ACD_FILEINFO_KEY env var.
 def test_real_key_verifies_cutelogix():
-    """If `ACD_FILEINFO_KEY` is set (64-char hex), the CuteLogix.ACD
-    reference verifies under that key. This is the test that confirms
-    a user's extracted key is correct."""
+    """If `ACD_FILEINFO_KEY` is set (64-char hex = 32-byte v2 key),
+    the bundled CuteLogix.ACD reference verifies under it. Skipped
+    when the env var is unset.
+
+    No v1 equivalent: the repo doesn't ship a v21-vintage sample
+    ACD. The v1 algorithm is covered by the structural / round-trip
+    cases above with arbitrary 126-byte keys."""
     raw_hex = os.environ.get("ACD_FILEINFO_KEY", "").strip()
     if not raw_hex:
         pytest.skip("ACD_FILEINFO_KEY env var not set; skipping real-key check")
@@ -133,14 +260,14 @@ def test_real_key_verifies_cutelogix():
         key = bytes.fromhex(raw_hex)
     except ValueError:
         pytest.fail(f"ACD_FILEINFO_KEY is not valid hex: {raw_hex[:8]}...")
-    if len(key) != HMAC_KEY_LENGTH:
+    if len(key) != HMAC_KEY_LENGTH_V2:
         pytest.fail(
             f"ACD_FILEINFO_KEY decoded to {len(key)} bytes; "
-            f"expected {HMAC_KEY_LENGTH}"
+            f"expected {HMAC_KEY_LENGTH_V2}"
         )
     acd = _read_acd()
     fi_off = find_fileinfo_offset(acd)
     assert verify_fileinfo(acd, fi_off, key=key), (
-        "ACD_FILEINFO_KEY does not verify CuteLogix.ACD — wrong key, "
+        "ACD_FILEINFO_KEY does not verify CuteLogix.ACD -- wrong key, "
         "or CuteLogix.ACD was modified post-extraction."
     )

--- a/test/test_integrity_fileinfo.py
+++ b/test/test_integrity_fileinfo.py
@@ -1,0 +1,146 @@
+"""Tests for the pure-function `FileInfo.Dat` HMAC API.
+
+These tests cover:
+- Algorithm structure (deterministic output, sensitive to key changes)
+- Error paths (no key, wrong-length key, out-of-bounds offset)
+- find_fileinfo_offset against a real ACD's record table
+
+A real-key verification test runs only when the `ACD_FILEINFO_KEY`
+env var is set (64-char hex string). Users with a legitimate Studio
+5000 install can extract their key and set the env var to run it;
+CI / strangers without the key skip it.
+"""
+import os
+
+import pytest
+
+from acd.integrity import (
+    FILEINFO_HEADER,
+    FILEINFO_LENGTH,
+    HMAC_KEY_LENGTH,
+    IntegrityKeyRequiredError,
+    compute_fileinfo,
+    find_fileinfo_offset,
+    verify_fileinfo,
+)
+
+
+CUTELOGIX = os.path.join("..", "resources", "CuteLogix.ACD")
+
+
+def _read_acd():
+    with open(CUTELOGIX, "rb") as fh:
+        return fh.read()
+
+
+def test_no_key_raises():
+    """Passing key=None raises IntegrityKeyRequiredError with a
+    helpful message that does NOT leak the key value or its source."""
+    acd = _read_acd()
+    fi_off = find_fileinfo_offset(acd)
+    with pytest.raises(IntegrityKeyRequiredError) as exc:
+        compute_fileinfo(acd, fi_off, key=None)
+    assert "key required" in str(exc.value).lower()
+
+
+def test_wrong_length_key_raises():
+    """A key that isn't exactly 32 bytes raises ValueError."""
+    acd = _read_acd()
+    fi_off = find_fileinfo_offset(acd)
+    for bad in (b"", b"x" * 16, b"y" * 31, b"z" * 33, b"w" * 64):
+        with pytest.raises(ValueError):
+            compute_fileinfo(acd, fi_off, key=bad)
+
+
+def test_compute_deterministic():
+    """Calling compute_fileinfo twice with the same inputs gives
+    identical output."""
+    acd = _read_acd()
+    fi_off = find_fileinfo_offset(acd)
+    key = b"\x00" * HMAC_KEY_LENGTH
+    first = compute_fileinfo(acd, fi_off, key=key)
+    second = compute_fileinfo(acd, fi_off, key=key)
+    assert first == second
+    assert len(first) == FILEINFO_LENGTH
+    assert first.startswith(FILEINFO_HEADER)
+
+
+def test_compute_changes_with_key():
+    """Different keys produce different HMAC outputs."""
+    acd = _read_acd()
+    fi_off = find_fileinfo_offset(acd)
+    fi_zero = compute_fileinfo(acd, fi_off, key=b"\x00" * HMAC_KEY_LENGTH)
+    fi_ones = compute_fileinfo(acd, fi_off, key=b"\xff" * HMAC_KEY_LENGTH)
+    assert fi_zero != fi_ones
+    # Both still start with the algorithm-selector header.
+    assert fi_zero[:2] == FILEINFO_HEADER
+    assert fi_ones[:2] == FILEINFO_HEADER
+
+
+def test_verify_round_trips_with_same_key():
+    """If we patch in the bytes compute_fileinfo emits, verify_fileinfo
+    returns True under the same key."""
+    acd = bytearray(_read_acd())
+    fi_off = find_fileinfo_offset(bytes(acd))
+    key = b"\x42" * HMAC_KEY_LENGTH
+    new_fi = compute_fileinfo(bytes(acd), fi_off, key=key)
+    acd[fi_off : fi_off + FILEINFO_LENGTH] = new_fi
+    assert verify_fileinfo(bytes(acd), fi_off, key=key)
+
+
+def test_verify_fails_with_wrong_key():
+    """verify_fileinfo returns False under a key different from the
+    one used to compute the FileInfo."""
+    acd = bytearray(_read_acd())
+    fi_off = find_fileinfo_offset(bytes(acd))
+    key_a = b"\x01" * HMAC_KEY_LENGTH
+    key_b = b"\x02" * HMAC_KEY_LENGTH
+    new_fi = compute_fileinfo(bytes(acd), fi_off, key=key_a)
+    acd[fi_off : fi_off + FILEINFO_LENGTH] = new_fi
+    assert not verify_fileinfo(bytes(acd), fi_off, key=key_b)
+
+
+def test_find_fileinfo_offset_in_cutelogix():
+    """The record-table scan locates FileInfo.Dat in CuteLogix.ACD."""
+    acd = _read_acd()
+    fi_off = find_fileinfo_offset(acd)
+    # Verify the byte range is plausible: should be within the file,
+    # and the stream content should start with the 02 00 algorithm
+    # selector header.
+    assert 0 < fi_off < len(acd) - FILEINFO_LENGTH
+    assert acd[fi_off : fi_off + 2] == FILEINFO_HEADER
+
+
+def test_out_of_bounds_offset_raises():
+    """A bogus fi_offset raises ValueError."""
+    acd = _read_acd()
+    key = b"\x00" * HMAC_KEY_LENGTH
+    with pytest.raises(ValueError):
+        compute_fileinfo(acd, -1, key=key)
+    with pytest.raises(ValueError):
+        compute_fileinfo(acd, len(acd) - 10, key=key)
+
+
+# Real-key test — only runs if user supplies the key via env var.
+def test_real_key_verifies_cutelogix():
+    """If `ACD_FILEINFO_KEY` is set (64-char hex), the CuteLogix.ACD
+    reference verifies under that key. This is the test that confirms
+    a user's extracted key is correct."""
+    raw_hex = os.environ.get("ACD_FILEINFO_KEY", "").strip()
+    if not raw_hex:
+        pytest.skip("ACD_FILEINFO_KEY env var not set; skipping real-key check")
+    try:
+        key = bytes.fromhex(raw_hex)
+    except ValueError:
+        pytest.fail(f"ACD_FILEINFO_KEY is not valid hex: {raw_hex[:8]}...")
+    if len(key) != HMAC_KEY_LENGTH:
+        pytest.fail(
+            f"ACD_FILEINFO_KEY decoded to {len(key)} bytes; "
+            f"expected {HMAC_KEY_LENGTH}"
+        )
+    acd = _read_acd()
+    fi_off = find_fileinfo_offset(acd)
+    assert verify_fileinfo(acd, fi_off, key=key), (
+        "ACD_FILEINFO_KEY does not verify CuteLogix.ACD — wrong key, "
+        "or CuteLogix.ACD was modified post-extraction."
+    )

--- a/test/test_integrity_project_key.py
+++ b/test/test_integrity_project_key.py
@@ -1,0 +1,122 @@
+"""Tests for the project-level FileInfo.Dat key binding.
+
+These tests use a `types.SimpleNamespace` as a stand-in for the
+project object — `set_fileinfo_key` doesn't care what type its first
+argument is, only that it can hold an attribute. That keeps these
+tests fast and free of the heavyweight `ExportL5x` import path used
+in the API integration test (Commit 5).
+
+The `verify_loaded_acd` round-trip test patches a fake FileInfo.Dat
+into a temp file using the same test key, then asserts verification
+passes.
+"""
+import os
+import shutil
+import types
+
+import pytest
+
+from acd.integrity import (
+    HMAC_KEY_LENGTH,
+    FILEINFO_LENGTH,
+    IntegrityKeyRequiredError,
+    clear_fileinfo_key,
+    compute_fileinfo,
+    find_fileinfo_offset,
+    get_fileinfo_key,
+    set_fileinfo_key,
+    verify_loaded_acd,
+)
+
+
+CUTELOGIX = os.path.join("..", "resources", "CuteLogix.ACD")
+
+
+def _project_stub():
+    return types.SimpleNamespace()
+
+
+def test_set_get_round_trip():
+    """A key stored via set_fileinfo_key comes back via get_fileinfo_key."""
+    project = _project_stub()
+    assert get_fileinfo_key(project) is None
+    key = b"\x11" * HMAC_KEY_LENGTH
+    set_fileinfo_key(project, key)
+    assert get_fileinfo_key(project) == key
+
+
+def test_set_accepts_bytearray_and_memoryview():
+    """bytes-like inputs are normalised to bytes."""
+    project = _project_stub()
+    key = bytearray(b"\x22" * HMAC_KEY_LENGTH)
+    set_fileinfo_key(project, key)
+    stored = get_fileinfo_key(project)
+    assert isinstance(stored, bytes)
+    assert stored == bytes(key)
+
+    project2 = _project_stub()
+    set_fileinfo_key(project2, memoryview(b"\x33" * HMAC_KEY_LENGTH))
+    assert get_fileinfo_key(project2) == b"\x33" * HMAC_KEY_LENGTH
+
+
+def test_set_rejects_wrong_length():
+    """Keys that aren't exactly 32 bytes raise ValueError."""
+    project = _project_stub()
+    for bad in (b"", b"x" * 16, b"y" * 31, b"z" * 33, b"w" * 64):
+        with pytest.raises(ValueError):
+            set_fileinfo_key(project, bad)
+    assert get_fileinfo_key(project) is None
+
+
+def test_set_rejects_non_bytes():
+    """Non-bytes inputs raise TypeError."""
+    project = _project_stub()
+    for bad in ("a" * HMAC_KEY_LENGTH, 12345, [0] * HMAC_KEY_LENGTH, None):
+        with pytest.raises(TypeError):
+            set_fileinfo_key(project, bad)
+
+
+def test_clear_removes_key():
+    """clear_fileinfo_key removes the binding."""
+    project = _project_stub()
+    set_fileinfo_key(project, b"\x44" * HMAC_KEY_LENGTH)
+    assert get_fileinfo_key(project) is not None
+    clear_fileinfo_key(project)
+    assert get_fileinfo_key(project) is None
+    # Clearing again is a no-op (no error).
+    clear_fileinfo_key(project)
+
+
+def test_verify_loaded_acd_no_key_raises(tmp_path):
+    """verify_loaded_acd without set_fileinfo_key raises a clear error."""
+    project = _project_stub()
+    dst = tmp_path / "cute.ACD"
+    shutil.copy(CUTELOGIX, dst)
+    with pytest.raises(IntegrityKeyRequiredError):
+        verify_loaded_acd(project, str(dst))
+
+
+def test_verify_loaded_acd_round_trips(tmp_path):
+    """If we patch FileInfo.Dat into the file using key K and call
+    verify_loaded_acd with key K registered on the project, verify
+    passes. With a different key, it fails."""
+    project = _project_stub()
+    key_a = b"\x55" * HMAC_KEY_LENGTH
+
+    # Copy the reference ACD, patch in a FileInfo.Dat computed under key_a.
+    with open(CUTELOGIX, "rb") as fh:
+        acd = bytearray(fh.read())
+    fi_off = find_fileinfo_offset(bytes(acd))
+    new_fi = compute_fileinfo(bytes(acd), fi_off, key=key_a)
+    acd[fi_off : fi_off + FILEINFO_LENGTH] = new_fi
+
+    dst = tmp_path / "cute_keyA.ACD"
+    with open(dst, "wb") as fh:
+        fh.write(bytes(acd))
+
+    set_fileinfo_key(project, key_a)
+    assert verify_loaded_acd(project, str(dst))
+
+    # Re-bind with a different key — verification must fail.
+    set_fileinfo_key(project, b"\x66" * HMAC_KEY_LENGTH)
+    assert not verify_loaded_acd(project, str(dst))

--- a/test/test_integrity_project_key.py
+++ b/test/test_integrity_project_key.py
@@ -1,14 +1,15 @@
 """Tests for the project-level FileInfo.Dat key binding.
 
 These tests use a `types.SimpleNamespace` as a stand-in for the
-project object — `set_fileinfo_key` doesn't care what type its first
+project object -- `set_fileinfo_key` doesn't care what type its first
 argument is, only that it can hold an attribute. That keeps these
 tests fast and free of the heavyweight `ExportL5x` import path used
-in the API integration test (Commit 5).
+in the API integration test.
 
 The `verify_loaded_acd` round-trip test patches a fake FileInfo.Dat
 into a temp file using the same test key, then asserts verification
-passes.
+passes -- exercised across both algorithms (32-byte modern, 126-byte
+older).
 """
 import os
 import shutil
@@ -17,8 +18,10 @@ import types
 import pytest
 
 from acd.integrity import (
-    HMAC_KEY_LENGTH,
+    ACCEPTABLE_KEY_LENGTHS,
     FILEINFO_LENGTH,
+    HMAC_KEY_LENGTH_V1,
+    HMAC_KEY_LENGTH_V2,
     IntegrityKeyRequiredError,
     clear_fileinfo_key,
     compute_fileinfo,
@@ -31,55 +34,78 @@ from acd.integrity import (
 
 CUTELOGIX = os.path.join("..", "resources", "CuteLogix.ACD")
 
+# Parametrize across both accepted key lengths.
+KEY_LENGTHS = [
+    pytest.param(HMAC_KEY_LENGTH_V2, id="v2-32-byte-modern"),
+    pytest.param(HMAC_KEY_LENGTH_V1, id="v1-126-byte-older"),
+]
+
 
 def _project_stub():
     return types.SimpleNamespace()
 
 
-def test_set_get_round_trip():
+@pytest.mark.parametrize("key_len", KEY_LENGTHS)
+def test_set_get_round_trip(key_len):
     """A key stored via set_fileinfo_key comes back via get_fileinfo_key."""
     project = _project_stub()
     assert get_fileinfo_key(project) is None
-    key = b"\x11" * HMAC_KEY_LENGTH
+    key = b"\x11" * key_len
     set_fileinfo_key(project, key)
     assert get_fileinfo_key(project) == key
 
 
-def test_set_accepts_bytearray_and_memoryview():
+@pytest.mark.parametrize("key_len", KEY_LENGTHS)
+def test_set_accepts_bytearray_and_memoryview(key_len):
     """bytes-like inputs are normalised to bytes."""
     project = _project_stub()
-    key = bytearray(b"\x22" * HMAC_KEY_LENGTH)
+    key = bytearray(b"\x22" * key_len)
     set_fileinfo_key(project, key)
     stored = get_fileinfo_key(project)
     assert isinstance(stored, bytes)
     assert stored == bytes(key)
 
     project2 = _project_stub()
-    set_fileinfo_key(project2, memoryview(b"\x33" * HMAC_KEY_LENGTH))
-    assert get_fileinfo_key(project2) == b"\x33" * HMAC_KEY_LENGTH
+    set_fileinfo_key(project2, memoryview(b"\x33" * key_len))
+    assert get_fileinfo_key(project2) == b"\x33" * key_len
+
+
+def test_set_accepts_both_lengths():
+    """Sanity: both 32 and 126 are accepted lengths."""
+    assert ACCEPTABLE_KEY_LENGTHS == (HMAC_KEY_LENGTH_V2, HMAC_KEY_LENGTH_V1)
+    project = _project_stub()
+    set_fileinfo_key(project, b"\xaa" * HMAC_KEY_LENGTH_V2)
+    assert len(get_fileinfo_key(project)) == HMAC_KEY_LENGTH_V2
+    set_fileinfo_key(project, b"\xbb" * HMAC_KEY_LENGTH_V1)
+    assert len(get_fileinfo_key(project)) == HMAC_KEY_LENGTH_V1
 
 
 def test_set_rejects_wrong_length():
-    """Keys that aren't exactly 32 bytes raise ValueError."""
+    """Keys whose length isn't in ACCEPTABLE_KEY_LENGTHS raise ValueError."""
     project = _project_stub()
-    for bad in (b"", b"x" * 16, b"y" * 31, b"z" * 33, b"w" * 64):
+    bad_lengths = (0, 1, 16, 31, 33, 64, 125, 127, 128)
+    for n in bad_lengths:
+        assert n not in ACCEPTABLE_KEY_LENGTHS, (
+            f"Test bug: {n} is in ACCEPTABLE_KEY_LENGTHS"
+        )
         with pytest.raises(ValueError):
-            set_fileinfo_key(project, bad)
+            set_fileinfo_key(project, b"\x00" * n)
     assert get_fileinfo_key(project) is None
 
 
 def test_set_rejects_non_bytes():
-    """Non-bytes inputs raise TypeError."""
+    """Non-bytes inputs raise TypeError, regardless of length."""
     project = _project_stub()
-    for bad in ("a" * HMAC_KEY_LENGTH, 12345, [0] * HMAC_KEY_LENGTH, None):
+    for bad in ("a" * 32, 12345, [0] * 32, None):
         with pytest.raises(TypeError):
             set_fileinfo_key(project, bad)
 
 
-def test_clear_removes_key():
+@pytest.mark.parametrize("key_len", KEY_LENGTHS)
+def test_clear_removes_key(key_len):
     """clear_fileinfo_key removes the binding."""
     project = _project_stub()
-    set_fileinfo_key(project, b"\x44" * HMAC_KEY_LENGTH)
+    set_fileinfo_key(project, b"\x44" * key_len)
     assert get_fileinfo_key(project) is not None
     clear_fileinfo_key(project)
     assert get_fileinfo_key(project) is None
@@ -96,12 +122,14 @@ def test_verify_loaded_acd_no_key_raises(tmp_path):
         verify_loaded_acd(project, str(dst))
 
 
-def test_verify_loaded_acd_round_trips(tmp_path):
+@pytest.mark.parametrize("key_len", KEY_LENGTHS)
+def test_verify_loaded_acd_round_trips(tmp_path, key_len):
     """If we patch FileInfo.Dat into the file using key K and call
     verify_loaded_acd with key K registered on the project, verify
-    passes. With a different key, it fails."""
+    passes. With a different key (same length), it fails. Exercised
+    across both algorithms (32-byte modern, 126-byte older)."""
     project = _project_stub()
-    key_a = b"\x55" * HMAC_KEY_LENGTH
+    key_a = b"\x55" * key_len
 
     # Copy the reference ACD, patch in a FileInfo.Dat computed under key_a.
     with open(CUTELOGIX, "rb") as fh:
@@ -110,13 +138,13 @@ def test_verify_loaded_acd_round_trips(tmp_path):
     new_fi = compute_fileinfo(bytes(acd), fi_off, key=key_a)
     acd[fi_off : fi_off + FILEINFO_LENGTH] = new_fi
 
-    dst = tmp_path / "cute_keyA.ACD"
+    dst = tmp_path / f"cute_{key_len}.ACD"
     with open(dst, "wb") as fh:
         fh.write(bytes(acd))
 
     set_fileinfo_key(project, key_a)
     assert verify_loaded_acd(project, str(dst))
 
-    # Re-bind with a different key — verification must fail.
-    set_fileinfo_key(project, b"\x66" * HMAC_KEY_LENGTH)
+    # Re-bind with a different key of the same length -- verification must fail.
+    set_fileinfo_key(project, b"\x66" * key_len)
     assert not verify_loaded_acd(project, str(dst))

--- a/test/test_save_acd_integrity.py
+++ b/test/test_save_acd_integrity.py
@@ -1,0 +1,164 @@
+"""Integration tests for save_acd's FileInfo.Dat regeneration.
+
+These tests exercise the full load_acd -> mutate -> save_acd path
+with a project-bound key, asserting that the written file's
+FileInfo.Dat verifies under that key.
+
+No real Studio key is used — the HMAC key is a test constant. We
+patch FileInfo.Dat in the source ACD before loading so that load
+sees a self-consistent file under the test key; then we save under
+the same key and verify the output.
+
+The test_api.py side of save_acd (no-key passthrough) is also
+covered here so the no-regression contract is explicit.
+"""
+import os
+import shutil
+
+import pytest
+
+from acd.api import load_acd, save_acd
+from acd.integrity import (
+    FILEINFO_LENGTH,
+    HMAC_KEY_LENGTH,
+    compute_fileinfo,
+    find_fileinfo_offset,
+    set_fileinfo_key,
+    verify_fileinfo,
+)
+
+
+CUTELOGIX = os.path.join("..", "resources", "CuteLogix.ACD")
+TEST_KEY = b"\x77" * HMAC_KEY_LENGTH
+
+
+def _make_acd_with_key(src_path, dst_path, key):
+    """Copy `src_path` to `dst_path`, patching FileInfo.Dat to verify under `key`."""
+    with open(src_path, "rb") as fh:
+        acd = bytearray(fh.read())
+    fi_off = find_fileinfo_offset(bytes(acd))
+    new_fi = compute_fileinfo(bytes(acd), fi_off, key=key)
+    acd[fi_off : fi_off + FILEINFO_LENGTH] = new_fi
+    with open(dst_path, "wb") as fh:
+        fh.write(bytes(acd))
+
+
+def test_save_acd_no_key_byte_equal_round_trip(tmp_path):
+    """save_acd without a key recovers the original container byte-for-byte.
+
+    This is the back-compat contract: callers that never set a key
+    continue to get the prior write-as-is behavior."""
+    src = tmp_path / "src.ACD"
+    dst = tmp_path / "dst.ACD"
+    shutil.copy(CUTELOGIX, src)
+
+    project = load_acd(str(src))
+    save_acd(project, str(dst))
+
+    src_bytes = open(src, "rb").read()
+    dst_bytes = open(dst, "rb").read()
+    assert src_bytes == dst_bytes
+
+
+def test_save_acd_with_key_recomputes_fileinfo(tmp_path):
+    """When a key is registered, save_acd writes a FileInfo.Dat that
+    verifies under that key — even after the project is loaded and
+    re-saved with no in-memory mutations."""
+    src = tmp_path / "src.ACD"
+    _make_acd_with_key(CUTELOGIX, src, TEST_KEY)
+
+    dst = tmp_path / "dst.ACD"
+    project = load_acd(str(src))
+    set_fileinfo_key(project, TEST_KEY)
+    save_acd(project, str(dst))
+
+    with open(dst, "rb") as fh:
+        out = fh.read()
+    fi_off = find_fileinfo_offset(out)
+    assert verify_fileinfo(out, fi_off, key=TEST_KEY)
+
+
+def test_save_acd_with_key_after_mutation_verifies(tmp_path):
+    """If we mutate a non-FI stream in _raw_files between load and save,
+    the recomputed FileInfo.Dat still verifies under the registered key.
+
+    Picks an unrelated file (Version.Log) so this stays a unit test of
+    the integrity-recompute path, not of higher-level mutations."""
+    src = tmp_path / "src.ACD"
+    _make_acd_with_key(CUTELOGIX, src, TEST_KEY)
+
+    dst = tmp_path / "dst.ACD"
+    project = load_acd(str(src))
+    set_fileinfo_key(project, TEST_KEY)
+
+    # Tweak a single byte in a small stream to force a different
+    # pre-image hash (so save MUST recompute or the file is broken).
+    target = "Version.Log"
+    assert target in project._raw_files
+    original = project._raw_files[target]
+    project._raw_files[target] = original + b"\x00"  # one-byte append
+
+    save_acd(project, str(dst))
+
+    with open(dst, "rb") as fh:
+        out = fh.read()
+    fi_off = find_fileinfo_offset(out)
+    assert verify_fileinfo(out, fi_off, key=TEST_KEY), (
+        "After mutating Version.Log, save_acd must produce a FileInfo.Dat "
+        "that verifies under the registered key."
+    )
+
+
+def test_save_acd_no_key_after_mutation_fi_stale(tmp_path):
+    """Without a registered key, save_acd writes the in-memory
+    FileInfo.Dat unchanged — even if other streams were mutated. The
+    output's FileInfo.Dat will therefore NOT verify under any key.
+
+    This documents the (intentionally backward-compatible) behaviour:
+    no key set → no automatic recompute → caller is responsible."""
+    src = tmp_path / "src.ACD"
+    _make_acd_with_key(CUTELOGIX, src, TEST_KEY)
+
+    dst = tmp_path / "dst.ACD"
+    project = load_acd(str(src))
+    # No set_fileinfo_key.
+    project._raw_files["Version.Log"] = (
+        project._raw_files["Version.Log"] + b"\x00"
+    )
+    save_acd(project, str(dst))
+
+    with open(dst, "rb") as fh:
+        out = fh.read()
+    fi_off = find_fileinfo_offset(out)
+    assert not verify_fileinfo(out, fi_off, key=TEST_KEY)
+
+
+# Real-key end-to-end — only runs if user supplies a Studio key.
+def test_save_acd_with_real_key_verifies_cutelogix(tmp_path):
+    """If ACD_FILEINFO_KEY is set, load_acd + save_acd on CuteLogix.ACD
+    produces a file whose FileInfo.Dat verifies under that key.
+
+    This is the test a Studio-equipped user runs to confirm the
+    extracted key flows end-to-end through save."""
+    raw_hex = os.environ.get("ACD_FILEINFO_KEY", "").strip()
+    if not raw_hex:
+        pytest.skip("ACD_FILEINFO_KEY env var not set; skipping real-key check")
+    try:
+        key = bytes.fromhex(raw_hex)
+    except ValueError:
+        pytest.fail(f"ACD_FILEINFO_KEY is not valid hex: {raw_hex[:8]}...")
+    if len(key) != HMAC_KEY_LENGTH:
+        pytest.fail(
+            f"ACD_FILEINFO_KEY decoded to {len(key)} bytes; "
+            f"expected {HMAC_KEY_LENGTH}"
+        )
+
+    dst = tmp_path / "out.ACD"
+    project = load_acd(CUTELOGIX)
+    set_fileinfo_key(project, key)
+    save_acd(project, str(dst))
+
+    with open(dst, "rb") as fh:
+        out = fh.read()
+    fi_off = find_fileinfo_offset(out)
+    assert verify_fileinfo(out, fi_off, key=key)

--- a/test/test_save_acd_integrity.py
+++ b/test/test_save_acd_integrity.py
@@ -4,10 +4,14 @@ These tests exercise the full load_acd -> mutate -> save_acd path
 with a project-bound key, asserting that the written file's
 FileInfo.Dat verifies under that key.
 
-No real Studio key is used — the HMAC key is a test constant. We
+No real Studio key is used -- the HMAC keys are test constants. We
 patch FileInfo.Dat in the source ACD before loading so that load
 sees a self-consistent file under the test key; then we save under
 the same key and verify the output.
+
+Both algorithms are covered:
+- 32-byte key + 02 00 selector (modern Studio)
+- 126-byte key + 01 00 selector (older Studio)
 
 The test_api.py side of save_acd (no-key passthrough) is also
 covered here so the no-regression contract is explicit.
@@ -19,9 +23,13 @@ import pytest
 
 from acd.api import load_acd, save_acd
 from acd.integrity import (
+    FILEINFO_HEADER_V1,
+    FILEINFO_HEADER_V2,
     FILEINFO_LENGTH,
-    HMAC_KEY_LENGTH,
+    HMAC_KEY_LENGTH_V1,
+    HMAC_KEY_LENGTH_V2,
     compute_fileinfo,
+    detect_fileinfo_selector,
     find_fileinfo_offset,
     set_fileinfo_key,
     verify_fileinfo,
@@ -29,11 +37,22 @@ from acd.integrity import (
 
 
 CUTELOGIX = os.path.join("..", "resources", "CuteLogix.ACD")
-TEST_KEY = b"\x77" * HMAC_KEY_LENGTH
+TEST_KEY_V2 = b"\x77" * HMAC_KEY_LENGTH_V2
+TEST_KEY_V1 = b"\x88" * HMAC_KEY_LENGTH_V1
+
+
+# Parametrize across both algorithms: (key_length, test_key, expected_header).
+ALGORITHMS = [
+    pytest.param(HMAC_KEY_LENGTH_V2, TEST_KEY_V2, FILEINFO_HEADER_V2, id="v2-32-byte-modern"),
+    pytest.param(HMAC_KEY_LENGTH_V1, TEST_KEY_V1, FILEINFO_HEADER_V1, id="v1-126-byte-older"),
+]
 
 
 def _make_acd_with_key(src_path, dst_path, key):
-    """Copy `src_path` to `dst_path`, patching FileInfo.Dat to verify under `key`."""
+    """Copy `src_path` to `dst_path`, patching FileInfo.Dat to verify under `key`.
+
+    Algorithm is auto-selected by key length: 32 -> v2 (02 00),
+    126 -> v1 (01 00)."""
     with open(src_path, "rb") as fh:
         acd = bytearray(fh.read())
     fi_off = find_fileinfo_offset(bytes(acd))
@@ -60,36 +79,40 @@ def test_save_acd_no_key_byte_equal_round_trip(tmp_path):
     assert src_bytes == dst_bytes
 
 
-def test_save_acd_with_key_recomputes_fileinfo(tmp_path):
+@pytest.mark.parametrize("key_len,test_key,expected_header", ALGORITHMS)
+def test_save_acd_with_key_recomputes_fileinfo(tmp_path, key_len, test_key, expected_header):
     """When a key is registered, save_acd writes a FileInfo.Dat that
-    verifies under that key — even after the project is loaded and
-    re-saved with no in-memory mutations."""
+    verifies under that key -- even after the project is loaded and
+    re-saved with no in-memory mutations. The on-disk selector matches
+    the key length (32 -> 02 00, 126 -> 01 00)."""
     src = tmp_path / "src.ACD"
-    _make_acd_with_key(CUTELOGIX, src, TEST_KEY)
+    _make_acd_with_key(CUTELOGIX, src, test_key)
 
     dst = tmp_path / "dst.ACD"
     project = load_acd(str(src))
-    set_fileinfo_key(project, TEST_KEY)
+    set_fileinfo_key(project, test_key)
     save_acd(project, str(dst))
 
     with open(dst, "rb") as fh:
         out = fh.read()
     fi_off = find_fileinfo_offset(out)
-    assert verify_fileinfo(out, fi_off, key=TEST_KEY)
+    assert out[fi_off : fi_off + 2] == expected_header
+    assert verify_fileinfo(out, fi_off, key=test_key)
 
 
-def test_save_acd_with_key_after_mutation_verifies(tmp_path):
+@pytest.mark.parametrize("key_len,test_key,expected_header", ALGORITHMS)
+def test_save_acd_with_key_after_mutation_verifies(tmp_path, key_len, test_key, expected_header):
     """If we mutate a non-FI stream in _raw_files between load and save,
     the recomputed FileInfo.Dat still verifies under the registered key.
 
     Picks an unrelated file (Version.Log) so this stays a unit test of
     the integrity-recompute path, not of higher-level mutations."""
     src = tmp_path / "src.ACD"
-    _make_acd_with_key(CUTELOGIX, src, TEST_KEY)
+    _make_acd_with_key(CUTELOGIX, src, test_key)
 
     dst = tmp_path / "dst.ACD"
     project = load_acd(str(src))
-    set_fileinfo_key(project, TEST_KEY)
+    set_fileinfo_key(project, test_key)
 
     # Tweak a single byte in a small stream to force a different
     # pre-image hash (so save MUST recompute or the file is broken).
@@ -103,7 +126,7 @@ def test_save_acd_with_key_after_mutation_verifies(tmp_path):
     with open(dst, "rb") as fh:
         out = fh.read()
     fi_off = find_fileinfo_offset(out)
-    assert verify_fileinfo(out, fi_off, key=TEST_KEY), (
+    assert verify_fileinfo(out, fi_off, key=test_key), (
         "After mutating Version.Log, save_acd must produce a FileInfo.Dat "
         "that verifies under the registered key."
     )
@@ -111,13 +134,13 @@ def test_save_acd_with_key_after_mutation_verifies(tmp_path):
 
 def test_save_acd_no_key_after_mutation_fi_stale(tmp_path):
     """Without a registered key, save_acd writes the in-memory
-    FileInfo.Dat unchanged — even if other streams were mutated. The
+    FileInfo.Dat unchanged -- even if other streams were mutated. The
     output's FileInfo.Dat will therefore NOT verify under any key.
 
     This documents the (intentionally backward-compatible) behaviour:
-    no key set → no automatic recompute → caller is responsible."""
+    no key set -> no automatic recompute -> caller is responsible."""
     src = tmp_path / "src.ACD"
-    _make_acd_with_key(CUTELOGIX, src, TEST_KEY)
+    _make_acd_with_key(CUTELOGIX, src, TEST_KEY_V2)
 
     dst = tmp_path / "dst.ACD"
     project = load_acd(str(src))
@@ -130,16 +153,36 @@ def test_save_acd_no_key_after_mutation_fi_stale(tmp_path):
     with open(dst, "rb") as fh:
         out = fh.read()
     fi_off = find_fileinfo_offset(out)
-    assert not verify_fileinfo(out, fi_off, key=TEST_KEY)
+    assert not verify_fileinfo(out, fi_off, key=TEST_KEY_V2)
 
 
-# Real-key end-to-end — only runs if user supplies a Studio key.
+def test_save_acd_key_length_must_match_source_selector(tmp_path):
+    """Registering a v2 key against an ACD whose FileInfo.Dat uses the
+    v1 selector (and vice versa) raises ValueError on save -- the
+    library refuses to silently write a file Studio would reject.
+
+    This is the cross-version safety check."""
+    src = tmp_path / "src.ACD"
+    # Make a v1-flavoured source (01 00 selector under TEST_KEY_V1).
+    _make_acd_with_key(CUTELOGIX, src, TEST_KEY_V1)
+
+    project = load_acd(str(src))
+    # Register a v2 key (32 bytes) against a v1 source -- mismatch.
+    set_fileinfo_key(project, TEST_KEY_V2)
+
+    dst = tmp_path / "dst.ACD"
+    with pytest.raises(ValueError, match=r"32-byte|0x0001"):
+        save_acd(project, str(dst))
+
+
+# Real-key v2 end-to-end check; gated on the ACD_FILEINFO_KEY env var.
 def test_save_acd_with_real_key_verifies_cutelogix(tmp_path):
     """If ACD_FILEINFO_KEY is set, load_acd + save_acd on CuteLogix.ACD
     produces a file whose FileInfo.Dat verifies under that key.
+    Skipped when the env var is unset.
 
-    This is the test a Studio-equipped user runs to confirm the
-    extracted key flows end-to-end through save."""
+    Confirms a modern-Studio key flows end-to-end through save. No
+    v1 equivalent: the repo doesn't ship a v21-vintage sample ACD."""
     raw_hex = os.environ.get("ACD_FILEINFO_KEY", "").strip()
     if not raw_hex:
         pytest.skip("ACD_FILEINFO_KEY env var not set; skipping real-key check")
@@ -147,10 +190,10 @@ def test_save_acd_with_real_key_verifies_cutelogix(tmp_path):
         key = bytes.fromhex(raw_hex)
     except ValueError:
         pytest.fail(f"ACD_FILEINFO_KEY is not valid hex: {raw_hex[:8]}...")
-    if len(key) != HMAC_KEY_LENGTH:
+    if len(key) != HMAC_KEY_LENGTH_V2:
         pytest.fail(
             f"ACD_FILEINFO_KEY decoded to {len(key)} bytes; "
-            f"expected {HMAC_KEY_LENGTH}"
+            f"expected {HMAC_KEY_LENGTH_V2}"
         )
 
     dst = tmp_path / "out.ACD"


### PR DESCRIPTION
## What

Adds `acd.integrity` so `save_acd` can produce ACDs that Studio 5000
accepts after modification. Without recomputing `FileInfo.Dat`, the
SDK rejects modified files with `RxDbE_FILE_NOT_VALID`.

Both observed selector variants are supported; the library picks the
algorithm by the registered key's length.

| Selector | HMAC input            | Key length |
|----------|-----------------------|------------|
| `01 00`  | `file − FileInfo.Dat` | 126 bytes  |
| `02 00`  | `sha256(file − FI)`   | 32 bytes   |

## Usage

```python
from acd.api import load_acd, save_acd, patch_rungs
from acd.integrity import set_fileinfo_key

project = load_acd("MyController.ACD")
set_fileinfo_key(project, bytes.fromhex(os.environ["ACD_FILEINFO_KEY"]))
patch_rungs(project, {...})
save_acd(project, "Modified.ACD")  # FileInfo.Dat recomputed; SDK opens cleanly
```

`save_acd` without a key is unchanged (byte-equal passthrough).

## Key

Not shipped — it's a per-Studio-version constant baked into the local
Studio 5000 install. Callers extract it once from their own install
and register via `set_fileinfo_key(project, key)`. No key appears in
source, tests, or commit history; tests use throwaway values.

## Tests

43 new tests across `test_integrity_fileinfo.py`,
`test_integrity_project_key.py`, and `test_save_acd_integrity.py` —
both algorithms parametrized, selector detection, error paths, and
end-to-end save with cross-key/source validation. 2 env-gated
real-key tests (skipped without `ACD_FILEINFO_KEY`) cover the v2
path end-to-end. All pass; the rest of the repo's suite is unchanged.

## Commits

```
49e5114  feat(integrity): support both 01 00 and 02 00 FileInfo selectors
fa7675c  feat(api): recompute FileInfo.Dat in save_acd when key is bound
ad1cc42  feat(integrity): add project-level set_fileinfo_key binding
b483e4a  feat(integrity): add FileInfo.Dat HMAC-SHA-256 verifier
```
