### PR TITLE
fix: survive per-record decode failures so newer-firmware ACDs import

### DIFF
--- a/acd/l5x/elements.py
+++ b/acd/l5x/elements.py
@@ -3,6 +3,8 @@ import os
 import re
 import shutil
 import struct
+
+from loguru import logger as log
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
@@ -2238,11 +2240,17 @@ class TaskBuilder(L5xElementBuilder):
         rate_str = str(rate_us // 1000) if task_type != "CONTINUOUS" else None
 
         # Scheduled programs: ext[0x01] value starts at BLOB offset 0x5A.
-        # Format: u16 count followed by N u32 comment_ids.
+        # Format: u16 count followed by N u32 comment_ids. The count is
+        # bounds-checked against the record: some firmware versions lay the
+        # record out differently and a garbage count must not read past the
+        # end of the buffer.
         prog_count = struct.unpack_from("<H", record, 0x5A)[0]
         scheduled_programs = []
         for i in range(prog_count):
-            cid = struct.unpack_from("<I", record, 0x5A + 2 + i * 4)[0]
+            offset = 0x5A + 2 + i * 4
+            if offset + 4 > len(record):
+                break
+            cid = struct.unpack_from("<I", record, offset)[0]
             prog_name = comment_id_to_program.get(cid)
             if prog_name:
                 scheduled_programs.append(ScheduledProgram(prog_name, prog_name))
@@ -2468,7 +2476,14 @@ class ControllerBuilder(L5xElementBuilder):
                 + " AND record_type=256"
             )
             for task_result in self._cur.fetchall():
-                tasks.append(TaskBuilder(self._cur, task_result[1]).build(comment_id_to_program))
+                try:
+                    tasks.append(
+                        TaskBuilder(self._cur, task_result[1]).build(comment_id_to_program)
+                    )
+                except Exception as e:
+                    # Task config offsets are firmware-version dependent; a
+                    # task that can't decode shouldn't abort the whole import.
+                    log.warning(f"Skipping undecodable task '{task_result[0]}': {e!r}")
 
         # Get the AOI Collection and get the AOIs
         self._cur.execute(

--- a/acd/l5x/export_l5x.py
+++ b/acd/l5x/export_l5x.py
@@ -23,6 +23,40 @@ from acd.record.nameless import NamelessRecord
 from acd.record.sbregion import SbRegionRecord
 
 
+def _parse_records(dat_path: str, parse_one, label: str) -> List[tuple]:
+    """Parse every record of a .Dat file, skipping records that fail.
+
+    Real-world ACDs (notably newer firmware like V33+) routinely contain a
+    handful of records the parsers don't understand yet; aborting the whole
+    import over one bad record makes the library unusable on those files.
+    Failures are counted and reported as a single warning instead. A missing
+    or wholly unreadable .Dat file degrades to an empty table the same way.
+    Returns the list of successfully parsed non-None tuples."""
+    if not os.path.exists(dat_path):
+        log.warning(f"{label}: file not found at {dat_path} - skipping")
+        return []
+    try:
+        records = DbExtract(dat_path).read().records.record
+    except Exception as e:
+        log.warning(f"{label}: unreadable database file ({e!r}) - skipping")
+        return []
+    out: List[tuple] = []
+    failed = 0
+    for record in records:
+        try:
+            t = parse_one(record)
+        except Exception:
+            failed += 1
+            continue
+        if t is not None:
+            out.append(t)
+    if failed:
+        log.warning(
+            f"{label}: skipped {failed} unparseable record(s) of {len(records)}"
+        )
+    return out
+
+
 @dataclass
 class ExportL5x:
     input_filename: os.PathLike
@@ -90,19 +124,18 @@ class ExportL5x:
                 self._raw_files[record.filename] = acd_fh.read(record.file_length)
 
         log.info("Getting records from ACD Comps file and storing in sqllite database")
-        comps_db = DbExtract(os.path.join(self._temp_dir, "Comps.Dat")).read()
         # Deduplicate by object_id. When duplicate object_ids exist (e.g. a routine that
         # appears twice in Comps.Dat with different record_type values), keep the entry
         # with the largest record because the smaller/later entry is typically a truncated
         # or partial record (e.g. record_type=271 vs 259 for routines) that fails to parse
         # correctly with RxGeneric. The full record is always the largest one.
         comps_by_id = {}
-        for record in comps_db.records.record:
-            t = CompsRecord.parse(record)
-            if t is not None:
-                oid = t[0]
-                if oid not in comps_by_id or len(t[5]) > len(comps_by_id[oid][5]):
-                    comps_by_id[oid] = t
+        for t in _parse_records(
+            os.path.join(self._temp_dir, "Comps.Dat"), CompsRecord.parse, "Comps"
+        ):
+            oid = t[0]
+            if oid not in comps_by_id or len(t[5]) > len(comps_by_id[oid][5]):
+                comps_by_id[oid] = t
         self._cur.executemany("INSERT INTO comps VALUES (?,?,?,?,?,?)", comps_by_id.values())
         self._db.commit()
 
@@ -119,24 +152,33 @@ class ExportL5x:
         log.info(
             "Getting records from ACD SbRegion file and storing in sqllite database"
         )
-        sb_region_db = DbExtract(os.path.join(self._temp_dir, "SbRegion.Dat")).read()
-        rung_tuples = [t for record in sb_region_db.records.record if (t := SbRegionRecord.parse(record, name_lookup)) is not None]
+        rung_tuples = _parse_records(
+            os.path.join(self._temp_dir, "SbRegion.Dat"),
+            lambda record: SbRegionRecord.parse(record, name_lookup),
+            "SbRegion",
+        )
         self._cur.executemany("INSERT INTO rungs VALUES (?,?,?)", rung_tuples)
         self._db.commit()
 
         log.info(
             "Getting records from ACD Comments file and storing in sqllite database"
         )
-        comments_db = DbExtract(os.path.join(self._temp_dir, "Comments.Dat")).read()
-        comment_tuples = [t for record in comments_db.records.record if (t := CommentsRecord.parse(record)) is not None]
+        comment_tuples = _parse_records(
+            os.path.join(self._temp_dir, "Comments.Dat"),
+            CommentsRecord.parse,
+            "Comments",
+        )
         self._cur.executemany("INSERT INTO comments VALUES (?,?,?,?,?,?,?,?,?)", comment_tuples)
         self._db.commit()
 
         log.info(
             "Getting records from ACD Nameless file and storing in sqllite database"
         )
-        nameless_db = DbExtract(os.path.join(self._temp_dir, "Nameless.Dat")).read()
-        nameless_tuples = [t for record in nameless_db.records.record if (t := NamelessRecord.parse(record)) is not None]
+        nameless_tuples = _parse_records(
+            os.path.join(self._temp_dir, "Nameless.Dat"),
+            NamelessRecord.parse,
+            "Nameless",
+        )
         self._cur.executemany("INSERT INTO nameless VALUES (?,?,?)", nameless_tuples)
         self._db.commit()
 


### PR DESCRIPTION
# Survive per-record decode failures so newer-firmware ACDs import

## Problem

A single undecodable record currently aborts the whole import. On newer-firmware ACDs (V33+) this makes files completely unloadable: one `UnicodeDecodeError` in an SbRegion record, or a `struct.error` while decoding one task's config, kills `ExportL5x` / `ImportProjectFromFile`. This looks like the same class of failure reported in #14 and #15.

## Change

- Ingestion (Comps / SbRegion / Comments / Nameless) now parses per record through a shared `_parse_records` helper: records that fail to parse are skipped and counted, reported as a single warning (`SbRegion: skipped N unparseable record(s) of M`). A missing or wholly unreadable `.Dat` degrades to an empty table instead of raising.
- `TaskBuilder` bounds-checks the scheduled-program list against the record buffer (some firmware versions lay the record out differently, and a garbage count must not read past the end), and a task that still can't decode is skipped with a warning instead of aborting `ControllerBuilder`.

## Validation

- Existing test suite passes unchanged.
- A production V33 ACD that previously failed with `UnicodeDecodeError` now imports fully (23 programs / 52 routines) and exports a complete L5X; the skipped-record warning makes the partial coverage visible instead of silent.
